### PR TITLE
Fixing glob patterns to work correctly for underlying Globby

### DIFF
--- a/Source/typescript/cli/PathHelper.ts
+++ b/Source/typescript/cli/PathHelper.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export class PathHelper {
+    /**
+     * Force path separator to be what is expected on Unix systems.
+     *
+     * The reason for this helper came from Plop having problems on Windows finding files in the template
+     * folder. This stems from Plop using a package called Globby for discovering files and it having a problem
+     * on windows with the forward slash used on Windows paths. So any path.* methods being used, which normalizes
+     * the path to be for the target platform will make a path that Globby didn't like.
+     *
+     * Read more here: https://github.com/sindresorhus/globby/issues/155
+     *
+     * @param {string} path Path to change
+     * @returns Path with path separator set to what is expected on unix based systems
+     */
+    static useUnixPathSeparator(path: string) {
+        return path.replace(/\\/g, '/');
+    }
+}
+

--- a/Source/typescript/cli/PlopHelper.ts
+++ b/Source/typescript/cli/PlopHelper.ts
@@ -5,7 +5,6 @@ import { Answers } from 'inquirer';
 import nodePlop from 'node-plop';
 import out from 'plop/src/console-out';
 
-
 const args = process.argv.slice(2);
 export const argv = require('minimist')(args);
 import ora from 'ora';

--- a/Source/typescript/cli/index.ts
+++ b/Source/typescript/cli/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './PlopHelper';
+export * from './PathHelper';

--- a/Source/typescript/create-dolittle-app/plopfile.ts
+++ b/Source/typescript/create-dolittle-app/plopfile.ts
@@ -8,6 +8,7 @@ import { Answers } from 'inquirer';
 import { Guid } from '@dolittle/rudiments';
 
 import { createMicroservice } from 'create-dolittle-microservice/dist/creation';
+import { PathHelper } from '@dolittle/vanir-cli';
 
 const templatesRootPath = path.join(rootPath, 'templates');
 const packageJson = require(path.join(rootPath, 'package.json'));
@@ -75,8 +76,8 @@ export default function (plop: NodePlopAPI) {
                 base: templatesRootPath,
                 destination: targetDirectory,
                 templateFiles: [
-                    templatesRootPath,
-                    path.join(templatesRootPath, '.*/**/*')
+                    PathHelper.useUnixPathSeparator(templatesRootPath),
+                    PathHelper.useUnixPathSeparator(path.join(templatesRootPath, '.*/**/*'))
                 ],
                 stripExtensions: ['hbs']
             } as AddManyActionConfig);

--- a/Source/typescript/create-dolittle-microservice/plopfile.ts
+++ b/Source/typescript/create-dolittle-microservice/plopfile.ts
@@ -7,6 +7,7 @@ import rootPath from './packageRoot';
 import { Answers } from 'inquirer';
 import { Guid } from '@dolittle/rudiments';
 import editJsonFile from 'edit-json-file';
+import { PathHelper } from '@dolittle/vanir-cli';
 
 const templatesRootPath = path.join(rootPath, 'templates', 'backend');
 const webTemplatesRootPath = path.join(rootPath, 'templates', 'web');
@@ -40,8 +41,8 @@ function getActionForTemplateDirectory(templateDirectory: string, targetDirector
         destination: targetDirectory,
         force: true,
         templateFiles: [
-            templateDirectory,
-            path.join(templateDirectory, '.*/**/*')
+            PathHelper.useUnixPathSeparator(templateDirectory),
+            PathHelper.useUnixPathSeparator(path.join(templateDirectory, '.*/**/*'))
         ],
         stripExtensions: ['hbs']
     } as AddManyActionConfig;


### PR DESCRIPTION
There is an issue in Globby which is being used in Plop that
causes problems with normalized paths that end up using
Windows style path separator. A workaround is to change it
to Unix style for the patterns.