### PR TITLE
Adding trailing / for graphql path

### DIFF
--- a/Source/web/Bindings.ts
+++ b/Source/web/Bindings.ts
@@ -15,7 +15,7 @@ export class Bindings {
     static initialize(configuration: Configuration) {
         const cache = new InMemoryCache();
         const link = new HttpLink({
-            uri: `${configuration.prefix}/graphql`
+            uri: `${configuration.prefix}/graphql/`
         });
 
         const client = new ApolloClient({


### PR DESCRIPTION
## Summary

Fixing a problem with the path for GraphQL client - needs a trailing /

### Fixed

- Added trailing slash for GraphQL paths for the client bindings