### PR TITLE
upgrade-webpack

### DIFF
--- a/Samples/Source/Aspnetcore/Web/package.json
+++ b/Samples/Source/Aspnetcore/Web/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",

--- a/Samples/Source/Portal/Web/package.json
+++ b/Samples/Source/Portal/Web/package.json
@@ -6,7 +6,8 @@
     "author": "Dolittle",
     "license": "MIT",
     "scripts": {
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot"
+        "build": "webpack --mode=production --progress",
+        "start:dev": "webpack serve --mode=development --progress --hot"
     },
     "dependencies": {
         "@shared/styles": "1.0.0",

--- a/Samples/Source/Typescript/Web/package.json
+++ b/Samples/Source/Typescript/Web/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",

--- a/Source/web/package.json
+++ b/Source/web/package.json
@@ -16,6 +16,10 @@
         "url": "https://github.com/dolittle-entropy/vanir/issues"
     },
     "homepage": "https://github.com/dolittle-entropy/vanir#readme",
+    "engineStrict": true,
+    "engines": {
+        "node": ">= 14"
+    },
     "readme": "",
     "files": [
         "dist",

--- a/Source/webpack/package.json
+++ b/Source/webpack/package.json
@@ -30,7 +30,7 @@
         "css-modules-typescript-loader": "4.0.1",
         "file-loader": "6.2.0",
         "fork-ts-checker-webpack-plugin": "6.1.0",
-        "html-webpack-plugin": "4.5.1",
+        "html-webpack-plugin": "5.1.0",
         "mini-css-extract-plugin": "1.3.4",
         "node-sass": "5.0.0",
         "postcss-loader": "4.1.0",
@@ -42,8 +42,8 @@
         "ts-loader": "8.0.14",
         "tsconfig-paths-webpack-plugin": "3.3.0",
         "url-loader": "4.1.1",
-        "webpack": "5.14.0",
-        "webpack-cli": "4.3.1",
+        "webpack": "5.22.0",
+        "webpack-cli": "4.5.0",
         "webpack-dev-server": "3.11.2"
     }
 }


### PR DESCRIPTION
## Summary

We've had issues with WebPack when using the dev-server and also all of a sudden broken builds due to the html-webpack-plugin not loading the ejs template file and rendering it.

### Fixed

- Upgraded to latest WebPack
- Upgraded to latest html-webpack-plugin
- Removing --watch option
- Updating templates to use webpack instead of webpack-cli directly
