### PR TITLE
Fix the hardcoded "Dolittle" tenant in the k8s production configuration to be configurable per template

### DIFF
--- a/Source/typescript/create-dolittle-microservice/templates/backend/Source/{{ pascalCase name }}/k8s/Production/configmap.yml
+++ b/Source/typescript/create-dolittle-microservice/templates/backend/Source/{{ pascalCase name }}/k8s/Production/configmap.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: application-{{applicationId}}
   name: {{lowerCase applicationName}}-prod-{{lowerCase name}}-env-variables
   labels:
-    tenant: Dolittle
+    tenant: {{tenant}}
     application: {{pascalCase applicationName}}-Prod
     microservice: {{pascalCase name}}
 data:
@@ -25,7 +25,7 @@ metadata:
   namespace: application-{{applicationId}}
   name: {{lowerCase applicationName}}-prod-{{lowerCase name}}-config-files
   labels:
-    tenant: Dolittle
+    tenant: {{tenant}}
     application: {{pascalCase applicationName}}-Prod
     microservice: {{pascalCase name}}
 data:


### PR DESCRIPTION
## Summary

This PR fixes the hardcoded "Dolittle" tenant in the k8s production configuration to be configurable per template

### Fixed

- Fix the hardcoded "Dolittle" tenant in the k8s production configuration to be configurable per template