### PR TITLE
Fixing capitalization for Tenant-ID not Tenant-Id

### DIFF
--- a/Documentation/microservice.md
+++ b/Documentation/microservice.md
@@ -40,7 +40,7 @@ be leveraged in the frontend and the backend.
 | Name | Description |
 | ----- | ----------- |
 | User-ID | The unique identifier of the user logging in |
-| Tenant-Id | The unique identifier of the tenant the user is logged into |
+| Tenant-ID | The unique identifier of the tenant the user is logged into |
 | Cookie | The authentication cookie used |
 
 ## Packaging

--- a/Source/typescript/backend/web/Context.ts
+++ b/Source/typescript/backend/web/Context.ts
@@ -14,7 +14,7 @@ export class Context {
     cookies: string = '';
 
     static fromRequest(req: Request): Context {
-        const tenantId = req.header('Tenant-Id') || TenantId.development;
+        const tenantId = req.header('Tenant-ID') || TenantId.development;
 
         const context: Context = {
             userId: req.header('User-ID') || '',


### PR DESCRIPTION
## Summary

Typo when getting HTTP header for Tenant

### Fixed

- Fixing usage of correct HTTP header for tenant; Tenant-ID not Tenant-Id
