### PR TITLE
Wrap Host runner in a CLS namespace run and use it for context

### DIFF
--- a/Source/typescript/backend/Host.ts
+++ b/Source/typescript/backend/Host.ts
@@ -19,20 +19,23 @@ import { container } from 'tsyringe';
 
 import { MongoDb } from './mongodb';
 import { Resources } from './resources';
+import { HostContext } from './HostContext';
 
 export class Host {
     static async start(startArguments: BackendArguments) {
-        const envPath = path.resolve(process.cwd(), '.env');
-        dotenv.config({ path: envPath });
-        const configuration = Configuration.create();
+        HostContext.run(async () => {
+            const envPath = path.resolve(process.cwd(), '.env');
+            dotenv.config({ path: envPath });
+            const configuration = Configuration.create();
 
-        DependencyInversion.initialize();
+            DependencyInversion.initialize();
 
-        container.registerInstance(Configuration, configuration);
+            container.registerInstance(Configuration, configuration);
 
-        MongoDb.initialize();
-        await Resources.initialize();
-        await Dolittle.initialize(configuration, startArguments.dolittleCallback);
-        await Express.initialize(configuration, startArguments.graphQLResolvers, startArguments.swaggerDoc, startArguments.expressCallback);
+            MongoDb.initialize();
+            await Resources.initialize();
+            await Dolittle.initialize(configuration, startArguments.dolittleCallback);
+            await Express.initialize(configuration, startArguments.graphQLResolvers, startArguments.swaggerDoc, startArguments.expressCallback);
+        })
     }
 }

--- a/Source/typescript/backend/Host.ts
+++ b/Source/typescript/backend/Host.ts
@@ -36,6 +36,6 @@ export class Host {
             await Resources.initialize();
             await Dolittle.initialize(configuration, startArguments.dolittleCallback);
             await Express.initialize(configuration, startArguments.graphQLResolvers, startArguments.swaggerDoc, startArguments.expressCallback);
-        })
+        });
     }
 }

--- a/Source/typescript/backend/HostContext.ts
+++ b/Source/typescript/backend/HostContext.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import cls from 'cls-hooked';
+
+export const HostContext = cls.createNamespace('d8646f1e-c0cf-4d9a-83e7-2b3bbf26078b');
+
+

--- a/Source/typescript/backend/data/GraphQLSchema.ts
+++ b/Source/typescript/backend/data/GraphQLSchema.ts
@@ -4,10 +4,12 @@
 import { Guid } from '@dolittle/rudiments';
 import { Constructor } from '@dolittle/types';
 import { buildSchema, Field, ObjectType, Query, Resolver, ResolverData } from 'type-graphql';
-import { GraphQLSchema } from 'graphql';
+import { GraphQLNamedType, print, isSpecifiedScalarType, isSpecifiedDirective, GraphQLArgument, GraphQLEnumType, GraphQLEnumValue, GraphQLField, GraphQLInputField, GraphQLInputObjectType, GraphQLInterfaceType, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLUnionType, InputValueDefinitionNode } from 'graphql';
 
 import { GuidScalar } from '.';
 import { container } from 'tsyringe';
+
+import { visitSchema, SchemaVisitor } from 'graphql-tools/dist/schemaVisitor';
 
 @ObjectType()
 class Nothing {
@@ -23,11 +25,107 @@ class NoQueries {
     }
 }
 
+class MyVisitor implements SchemaVisitor {
+    schema!: GraphQLSchema;
+    visitSchema(schema: GraphQLSchema): void {
+
+    }
+    visitScalar(scalar: GraphQLScalarType): void | GraphQLScalarType | null {
+
+    }
+    visitObject(object: GraphQLObjectType<any, any>): void | GraphQLObjectType<any, any> | null {
+
+    }
+    visitFieldDefinition(field: GraphQLField<any, any, { [key: string]: any; }>, details: { objectType: GraphQLInterfaceType | GraphQLObjectType<any, any>; }): void | GraphQLField<any, any, { [key: string]: any; }> | null {
+
+    }
+    visitArgumentDefinition(argument: GraphQLArgument, details: { field: GraphQLField<any, any, { [key: string]: any; }>; objectType: GraphQLInterfaceType | GraphQLObjectType<any, any>; }): void | GraphQLArgument | null {
+
+    }
+    visitInterface(iface: GraphQLInterfaceType): void | GraphQLInterfaceType | null {
+
+    }
+    visitUnion(union: GraphQLUnionType): void | GraphQLUnionType | null {
+
+    }
+    visitEnum(type: GraphQLEnumType): void | GraphQLEnumType | null {
+
+    }
+    visitEnumValue(value: GraphQLEnumValue, details: { enumType: GraphQLEnumType; }): void | GraphQLEnumValue | null {
+
+    }
+    visitInputObject(object: GraphQLInputObjectType): void | GraphQLInputObjectType | null {
+
+    }
+    visitInputFieldDefinition(field: GraphQLInputField, details: { objectType: GraphQLInputObjectType; }): void | GraphQLInputField | null {
+        let newField: GraphQLInputField = {
+            ...field, ... {
+                description: 'Awesomeness',
+                extensions: {
+                    'hello': 'world'
+                }
+            }
+        };
+
+        /*
+        let astNode: InputValueDefinitionNode = {
+            ...field.astNode, ... {
+                directives: [{
+                    name: {
+                        value: 'deprecated'
+                    },
+                    arguments: [
+                        {
+                            name: 'reason',
+                            value: 'Because I can'
+                        }
+
+
+                    ]
+
+
+                }]
+            }
+        } as any;
+
+        newField.astNode = astNode;*/
+
+        return newField;
+    }
+
+}
+
+// https://github.com/graphql/graphql-js/issues/869
+export function printSchemaWithDirectives(schema: GraphQLSchema) {
+    const str = Object
+        .keys(schema.getTypeMap())
+        .filter(k => !k.match(/^__/))
+        .reduce((accum, name) => {
+            const type = schema.getType(name)! as GraphQLNamedType;
+            const val = !isSpecifiedScalarType(type)
+                ? accum += `${print(type.astNode!)}\n`
+                : accum;
+
+            return val;
+        }, '');
+
+    return schema
+        .getDirectives()
+        .reduce((accum, d) => {
+            const val = !isSpecifiedDirective(d)
+                ? accum += `${print(d.astNode!)}\n`
+                : accum;
+            return val;
+        }, str + `${print(schema.astNode!)}\n`);
+}
 
 export async function getSchemaFor(resolvers: Constructor[]): Promise<GraphQLSchema> {
 
     const schema = await buildSchema({
         resolvers: resolvers.length > 0 ? resolvers as any : [NoQueries],
+        emitSchemaFile: {
+
+        },
         container: {
             get(someClass: any, resolverData: ResolverData<any>): any | Promise<any> {
                 return container.resolve(someClass);
@@ -36,7 +134,18 @@ export async function getSchemaFor(resolvers: Constructor[]): Promise<GraphQLSch
         scalarsMap: [
             { type: Guid, scalar: GuidScalar }
         ]
+
     });
+
+    visitSchema(schema, (type, methodName) => {
+        console.log(methodName);
+        if (methodName === 'visitInputFieldDefinition') {
+            return [new MyVisitor()]
+        }
+        return [];
+    });
+
+    const schemaAsString = printSchemaWithDirectives(schema);
 
     return schema;
 }

--- a/Source/typescript/backend/mongodb/MongoDbContext.ts
+++ b/Source/typescript/backend/mongodb/MongoDbContext.ts
@@ -3,21 +3,14 @@
 
 import cls from 'cls-hooked';
 import { Constructor } from '@dolittle/types';
-import { Request, Response, NextFunction } from 'express';
+import { HostContext } from '../HostContext';
 
-const ns = cls.createNamespace('c5da357c-42b4-4c04-8ff5-2ba3804ede42');
-
-export function MongoDbContextMiddleware(req: Request, res: Response, next: NextFunction) {
-    ns.run(() => {
-        next();
-    });
-}
-
+const CollectionPrefix = 'MongoDbCollection:';
 
 export function setCollectionType(collectionName: string, type: Constructor) {
-    ns.set(collectionName, type);
+    HostContext.set(`${CollectionPrefix}${collectionName}`, type);
 }
 
 export function getCollectionType(collectionName): Constructor | undefined {
-    return ns.get(collectionName);
+    return HostContext.get(`${CollectionPrefix}${collectionName}`);
 }

--- a/Source/typescript/backend/web/Context.ts
+++ b/Source/typescript/backend/web/Context.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import cls from 'cls-hooked';
 import { Request, Response, NextFunction } from 'express';
 import { TenantId } from '@dolittle/sdk.execution';
+import { HostContext } from '../HostContext';
 
 const ContextKey = 'Context';
-const ns = cls.createNamespace('0e852ce9-ef09-45d2-b64b-4868de226563');
 
 export class Context {
     userId: string = '';
@@ -26,25 +25,12 @@ export class Context {
     }
 };
 
-
 export function ContextMiddleware(req: Request, res: Response, next: NextFunction) {
-    ns.run(() => {
-        const context = Context.fromRequest(req);
-
-        if (ns.active) {
-            ns.set(ContextKey, context);
-        }
-        next();
-    });
+    const context = Context.fromRequest(req);
+    HostContext.set(ContextKey, context);
+    next();
 }
 
 export function getCurrentContext(): Context {
-    if (ns.active) {
-        return ns.get(ContextKey) as Context;
-    }
-    return {
-        userId: '',
-        tenantId: TenantId.development,
-        cookies: ''
-    };
+    return HostContext.get(ContextKey) as Context;
 }


### PR DESCRIPTION
## Summary

Making sure we have the right context both for regular Express middlewares and GraphQL.

### Fixed

- Fixes so that the context is correct in all call paths

