### PR TITLE
make start dev work in portal template

### DIFF
--- a/Source/typescript/create-dolittle-microservice/templates/portal/Source/{{ pascalCase name }}/Web/package.json.hbs
+++ b/Source/typescript/create-dolittle-microservice/templates/portal/Source/{{ pascalCase name }}/Web/package.json.hbs
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",


### PR DESCRIPTION
## Summary

- the start:dev script in portal template does not work with cli, update to use webpack directly

### Fixed

- the start:dev script in portal template does not work with cli, update to use webpack directly

