### PR TITLE
Fixes webpack:dev scripts to use webpack and not webpack-cli

### DIFF
--- a/Documentation/frontend/anatomy-of-a-frontend.md
+++ b/Documentation/frontend/anatomy-of-a-frontend.md
@@ -133,7 +133,7 @@ package.json:
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",

--- a/Source/typescript/create-dolittle-microservice/templates/portal/Source/{{ pascalCase name }}/Web/package.json.hbs
+++ b/Source/typescript/create-dolittle-microservice/templates/portal/Source/{{ pascalCase name }}/Web/package.json.hbs
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",

--- a/Source/typescript/create-dolittle-microservice/templates/web/Source/{{ pascalCase name }}/Web/package.json.hbs
+++ b/Source/typescript/create-dolittle-microservice/templates/web/Source/{{ pascalCase name }}/Web/package.json.hbs
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "build:dev": "webpack --mode=development",
-        "start:dev": "webpack-cli serve --mode=development --watch --progress --hot",
+        "start:dev": "webpack serve --mode=development --progress --hot",
         "clean": "tsc -b --clean",
         "lint": "eslint '**/*.{js,ts,tsx}' --quiet --fix",
         "lint:ci": "eslint '**/*.{js,ts,tsx}' --quiet",


### PR DESCRIPTION
## Summary

Makes scaffolding of new projects correct.

### Fixed

- Fixes so we don't use webpack-cli but webpack directly for yarn:dev scripts in package.json

