### PR TITLE
Exporting all sub modules to avoid dist imports

### DIFF
--- a/Source/typescript/backend/index.ts
+++ b/Source/typescript/backend/index.ts
@@ -7,11 +7,23 @@ export * from './logging';
 export * from './Context';
 export * from './HostContext';
 
-export * as data from './data';
-export * as dolittle from './dolittle';
-export * as logging from './logging';
-export * as tsoa from './tsoa';
-export * as web from './web';
+import * as data from './data';
+import * as dolittle from './dolittle';
+import * as logging from './logging';
+import * as tsoa from './tsoa';
+import * as mongodb from './mongodb';
+import * as resources from './resources';
+import * as web from './web';
+
+export {
+    data,
+    dolittle,
+    logging,
+    mongodb,
+    tsoa,
+    resources,
+    web
+};
 
 export {
     IEventStore,


### PR DESCRIPTION
## Summary

Exporting sub modules.

### Fixed

- To avoid consumers of packages having to import `dist` relative paths within the package, we now export the sub-modules as part of the top-level package (e.g. data will be @dolittle/vanir-backend/data instead of @dolittle/vanir-backend/dist/data)
