### PR TITLE
Default collection name compatibility with Mongoose

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
         "Configurator",
         "Deduplication",
         "MUUID",
+        "Pluralizer",
         "actionbar",
         "dependencyinversion",
         "eventstore",

--- a/Source/typescript/backend/mongodb/CollectionNamePluralizer.ts
+++ b/Source/typescript/backend/mongodb/CollectionNamePluralizer.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Based on : https://github.com/vkarpov15/mongoose-legacy-pluralize
+
+
+const rules = [
+    [/(m)an$/gi, '$1en'],
+    [/(pe)rson$/gi, '$1ople'],
+    [/(child)$/gi, '$1ren'],
+    [/^(ox)$/gi, '$1en'],
+    [/(ax|test)is$/gi, '$1es'],
+    [/(octop|vir)us$/gi, '$1i'],
+    [/(alias|status)$/gi, '$1es'],
+    [/(bu)s$/gi, '$1ses'],
+    [/(buffal|tomat|potat)o$/gi, '$1oes'],
+    [/([ti])um$/gi, '$1a'],
+    [/sis$/gi, 'ses'],
+    [/(?:([^f])fe|([lr])f)$/gi, '$1$2ves'],
+    [/(hive)$/gi, '$1s'],
+    [/([^aeiouy]|qu)y$/gi, '$1ies'],
+    [/(x|ch|ss|sh)$/gi, '$1es'],
+    [/(matr|vert|ind)ix|ex$/gi, '$1ices'],
+    [/([m|l])ouse$/gi, '$1ice'],
+    [/(kn|w|l)ife$/gi, '$1ives'],
+    [/(quiz)$/gi, '$1zes'],
+    [/s$/gi, 's'],
+    [/([^a-z])$/, '$1'],
+    [/$/gi, 's']
+];
+
+const uncountables = [
+    'advice',
+    'energy',
+    'excretion',
+    'digestion',
+    'cooperation',
+    'health',
+    'justice',
+    'labour',
+    'machinery',
+    'equipment',
+    'information',
+    'pollution',
+    'sewage',
+    'paper',
+    'money',
+    'species',
+    'series',
+    'rain',
+    'rice',
+    'fish',
+    'sheep',
+    'moose',
+    'deer',
+    'news',
+    'expertise',
+    'status',
+    'media'
+];
+
+/*!
+ * Pluralize function.
+ *
+ * @author TJ Holowaychuk (extracted from _ext.js_)
+ * @param {String} string to pluralize
+ * @api private
+ */
+export function pluralize(str) {
+    let found;
+    str = str.toLowerCase();
+    if (!~uncountables.indexOf(str)) {
+        found = rules.filter(function (rule) {
+            return str.match(rule[0]);
+        });
+        if (found[0]) {
+            return str.replace(found[0][0], found[0][1]);
+        }
+    }
+    return str;
+}

--- a/Source/typescript/backend/mongodb/MongoDatabase.ts
+++ b/Source/typescript/backend/mongodb/MongoDatabase.ts
@@ -7,6 +7,7 @@ import { injectable } from 'tsyringe';
 import { IMongoDatabase } from './IMongoDatabase';
 import { MongoDbReadModelsConfiguration } from './MongoDbReadModelsConfiguration';
 import { setCollectionType } from './MongoDbContext';
+import { pluralize } from './CollectionNamePluralizer';
 
 /* eslint-disable @typescript-eslint/unified-signatures */
 declare module 'mongodb' {
@@ -27,7 +28,7 @@ export class MongoDatabase implements IMongoDatabase {
     collection<TSchema = any>(type: Constructor<TSchema>, name: string): Promise<Collection<TSchema>>;
     collection<TSchema = any>(type: Constructor<TSchema>, name: string, options: DbCollectionOptions): Promise<Collection<TSchema>>;
     async collection<TSchema = any>(typeOrName: Constructor<TSchema> | string, nameOrOption?: string | DbCollectionOptions, options?: DbCollectionOptions): Promise<Collection<TSchema>> {
-        let name = (typeOrName instanceof String) ? (typeOrName as string) : (typeOrName as Constructor).name;
+        let name = (typeOrName instanceof String) ? (typeOrName as string) : pluralize((typeOrName as Constructor).name);
 
         if (nameOrOption) {
             if (nameOrOption instanceof String) {

--- a/Source/typescript/backend/mongodb/index.ts
+++ b/Source/typescript/backend/mongodb/index.ts
@@ -12,3 +12,4 @@ export * from './IMongoDatabase';
 export * from './MongoDatabaseProvider';
 export * from './MongoDbReadModelsConfiguration';
 export * from './MongoDbContext';
+export * from './CollectionNamePluralizer';


### PR DESCRIPTION
## Summary

This fixes an undesired breaking change from version 8 to 9. Collection names would by default be the type name- but we expect the same default behavior as with Mongoose, which is making it lowercase and pluralized. This particular code is now brought in from Mongoose to make sure we have the same behavior and is as expected.

### Fixed

- Collection names are now correct; lowercase + pluralized

