### PR TITLE
Avoid getting double / for rooted paths

### DIFF
--- a/Source/DotNET/Backend/Config/Configuration.cs
+++ b/Source/DotNET/Backend/Config/Configuration.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Vanir.Backend.Config
         public bool IsDevelopment => Environment == "development";
         public bool IsProduction => Environment == "production";
 
-        public string Prefix => $"{(IsRooted ? "" : "/_")}/{RouteSegment}";
+        public string Prefix => $"{(IsRooted ? "" : "/_")}{(RouteSegment.Length > 0 ? "/" : "")}{RouteSegment}";
         public string GraphQLRoute => $"{Prefix}/graphql";
 
         public string GraphQLPlaygroundRoute => $"{GraphQLRoute}/ui";


### PR DESCRIPTION
### Fixed

- When paths are rooted as described in `vanir.json` - the GraphQL paths will now be single / at the beginning.

