### PR TITLE
Adding full support for any Concepts - automatic conversion to base type

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Owner.cs
+++ b/Samples/Source/Aspnetcore/Backend/Owner.cs
@@ -1,13 +1,20 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Dolittle.SDK.Concepts;
 
 namespace Backend
 {
+    public class OwnerId : ConceptAs<Guid>
+    {
+
+        public static implicit operator OwnerId(Guid id) => new() { Value = id };
+    }
+
     public class Owner
     {
         [Key]
-        public Guid Id { get; set; }
+        public OwnerId Id { get; set; }
         [Required(ErrorMessage = "Name is required")]
         public string Name { get; set; }
         public string Address { get; set; }

--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -14,12 +14,11 @@ namespace Backend
         }
 
         [Mutation]
-        public bool DoSomething()
+        public bool DoSomething(OwnerId input)
         {
-            Console.WriteLine("Hello world");
+            Console.WriteLine($"Hello world - {input}");
             return true;
         }
-
 
         [Query("MyCustomName")]
         public Owner TheOwner(int id)

--- a/Source/DotNET/Backend/Concepts/ConceptExtensions.cs
+++ b/Source/DotNET/Backend/Concepts/ConceptExtensions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Concepts;
+using Dolittle.Vanir.Backend.Reflection;
+
+namespace Dolittle.Vanir.Backend.Concepts
+{
+    /// <summary>
+    /// Provides extensions related to <see cref="Type">types</see> and others related to <see cref="ConceptAs{T}"/>.
+    /// </summary>
+    public static class ConceptExtensions
+    {
+        /// <summary>
+        /// Check if a type is a concept or not.
+        /// </summary>
+        /// <param name="objectType"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a concept, false if not.</returns>
+        public static bool IsConcept(this Type objectType)
+        {
+            return objectType.IsDerivedFromOpenGeneric(typeof(ConceptAs<>));
+        }
+
+        /// <summary>
+        /// Check if an object is an instance of a concept or not.
+        /// </summary>
+        /// <param name="instance">instance to check.</param>
+        /// <returns>True if object is a concept, false if not.</returns>
+        public static bool IsConcept(this object instance)
+        {
+            return IsConcept(instance.GetType());
+        }
+
+        /// <summary>
+        /// Get the type of the value inside a <see cref="ConceptAs{T}"/>.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to get value type from.</param>
+        /// <returns>The type of the <see cref="ConceptAs{T}"/> value.</returns>
+        public static Type GetConceptValueType(this Type type)
+        {
+            return ConceptMap.GetConceptValueType(type);
+        }
+
+        /// <summary>
+        /// Takes a Concept{T} value object as an object and returns the correct primitive value, also as an object.
+        /// </summary>
+        /// <param name="conceptObject">The concept as an object.</param>
+        /// <returns>The value of the primitive type on which the concept is based.</returns>
+        public static object GetConceptValue(this object conceptObject)
+        {
+            if (!IsConcept(conceptObject)) throw new TypeIsNotAConcept(conceptObject.GetType());
+
+            return ((dynamic)conceptObject).Value;
+        }
+    }
+}

--- a/Source/DotNET/Backend/Concepts/ConceptFactory.cs
+++ b/Source/DotNET/Backend/Concepts/ConceptFactory.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using Dolittle.SDK.Concepts;
+using Dolittle.Vanir.Backend.Reflection;
+
+namespace Dolittle.Vanir.Backend.Concepts
+{
+    /// <summary>
+    /// Factory to create an instance of a <see cref="ConceptAs{T}"/> from the Type and Underlying value.
+    /// </summary>
+    public static class ConceptFactory
+    {
+        /// <summary>
+        /// Creates an instance of a <see cref="ConceptAs{T}"/> given the type and underlying value.
+        /// </summary>
+        /// <param name="type">Type of the ConceptAs to create.</param>
+        /// <param name="value">Value to give to this instance.</param>
+        /// <returns>An instance of a ConceptAs with the specified value.</returns>
+        public static object CreateConceptInstance(Type type, object value)
+        {
+            var val = new object();
+
+            var valueProperty = type.GetTypeInfo().GetProperty("Value");
+            var genericArgumentType = GetPrimitiveTypeConceptIsBasedOn(type);
+
+            if (genericArgumentType.IsGuid())
+            {
+                if (value == null)
+                {
+                    val = Guid.Empty;
+                }
+                else if (value.GetType().IsGuid())
+                {
+                    val = value;
+                }
+                else if (value.GetType().IsString())
+                {
+                    val = Guid.Parse(value.ToString());
+                }
+                else
+                {
+                    val = value.GetType() == typeof(byte[]) ? new Guid(value as byte[]) : (object)Guid.Empty;
+                }
+            }
+            else if (genericArgumentType.IsString())
+            {
+                val = value ?? string.Empty;
+            }
+            else if (genericArgumentType.IsDate())
+            {
+                val = value ?? default(DateTime);
+            }
+            else if (genericArgumentType.IsDateTimeOffset())
+            {
+                val = value ?? default(DateTimeOffset);
+            }
+            else if (genericArgumentType.IsAPrimitiveType())
+            {
+                val = value ?? Activator.CreateInstance(valueProperty.PropertyType);
+            }
+
+            if (val.GetType() != genericArgumentType && !IsGuidFromString(genericArgumentType, val))
+                val = Convert.ChangeType(val, genericArgumentType, null);
+
+            object instance;
+            if (type.HasDefaultConstructor())
+            {
+                instance = Activator.CreateInstance(type);
+                valueProperty.SetValue(instance, val, null);
+            }
+            else
+            {
+                instance = type.GetNonDefaultConstructor(new Type[] { genericArgumentType }).Invoke(new object[] { val });
+            }
+
+            return instance;
+        }
+
+        static Type GetPrimitiveTypeConceptIsBasedOn(Type conceptType)
+        {
+            return ConceptMap.GetConceptValueType(conceptType);
+        }
+
+        static bool IsGuidFromString(Type genericArgumentType, object value)
+        {
+            return genericArgumentType == typeof(Guid) && value.GetType() == typeof(string);
+        }
+    }
+}

--- a/Source/DotNET/Backend/Concepts/ConceptMap.cs
+++ b/Source/DotNET/Backend/Concepts/ConceptMap.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Dolittle.SDK.Concepts;
+
+namespace Dolittle.Vanir.Backend.Concepts
+{
+    /// <summary>
+    /// Maps a concept type to the underlying primitive type.
+    /// </summary>
+    public static class ConceptMap
+    {
+        static readonly ConcurrentDictionary<Type, Type> _cache = new();
+
+        /// <summary>
+        /// Get the type of the value in a <see cref="ConceptAs{T}"/>.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to get value type from.</param>
+        /// <returns>The type of the <see cref="ConceptAs{T}"/> value.</returns>
+        public static Type GetConceptValueType(Type type)
+        {
+            return _cache.GetOrAdd(type, GetPrimitiveType);
+        }
+
+        static Type GetPrimitiveType(Type type)
+        {
+            var conceptType = type;
+            for (; ;)
+            {
+                if (conceptType == typeof(ConceptAs<>)) break;
+
+                var typeProperty = conceptType.GetTypeInfo().GetProperty("UnderlyingType");
+                if (typeProperty != null)
+                {
+                    return (Type)typeProperty.GetValue(null);
+                }
+
+                if (conceptType == typeof(object)) break;
+
+                conceptType = conceptType.GetTypeInfo().BaseType;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/DotNET/Backend/Concepts/TypeIsNotAConcept.cs
+++ b/Source/DotNET/Backend/Concepts/TypeIsNotAConcept.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.SDK.Concepts;
+
+namespace Dolittle.Vanir.Backend.Concepts
+{
+    /// <summary>
+    /// Exception that gets thrown when a <see cref="Type"/> is not a <see cref="ConceptAs{T}"/>.
+    /// </summary>
+    public class TypeIsNotAConcept : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeIsNotAConcept"/> class.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> that is not a concept.</param>
+        public TypeIsNotAConcept(Type type)
+            : base($"Type '{type.AssemblyQualifiedName}' is not a concept - implement ConceptAs<> for it to be one.")
+        {
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/Concepts/ConceptAsGraphQLBuilderExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/Concepts/ConceptAsGraphQLBuilderExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Dolittle.Vanir.Backend.Concepts;
+using HotChocolate.Execution.Configuration;
+using HotChocolate.Types;
+using HotChocolate.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Concepts
+{
+    public static class ConceptAsGraphQLBuilderExtensions
+    {
+        public static IRequestExecutorBuilder AddConceptTypeConverter(this IRequestExecutorBuilder builder, Type type)
+        {
+            var conceptValueType = type.GetConceptValueType();
+
+            if (conceptValueType == typeof(bool))
+            {
+                builder.BindRuntimeType(type, typeof(BooleanType));
+            }
+            else if (conceptValueType == typeof(decimal))
+            {
+                builder.BindRuntimeType(type, typeof(DecimalType));
+            }
+            else if (conceptValueType == typeof(double))
+            {
+                builder.BindRuntimeType(type, typeof(FloatType));
+            }
+            else if (conceptValueType == typeof(float))
+            {
+                builder.BindRuntimeType(type, typeof(FloatType));
+            }
+            else if (conceptValueType == typeof(Guid))
+            {
+                builder.BindRuntimeType(type, typeof(UuidType));
+            }
+            else if (conceptValueType == typeof(int))
+            {
+                builder.BindRuntimeType(type, typeof(IntType));
+            }
+            else if (conceptValueType == typeof(long))
+            {
+                builder.BindRuntimeType(type, typeof(IntType));
+            }
+            else if (conceptValueType == typeof(string))
+            {
+                builder.BindRuntimeType(type, typeof(StringType));
+            }
+
+            var provider = Activator.CreateInstance(typeof(ConceptAsTypeProvider<>).MakeGenericType(type));
+            builder.Services.AddSingleton(provider as IChangeTypeProvider);
+
+            return builder;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/Concepts/ConceptAsTypeProvider.cs
+++ b/Source/DotNET/Backend/GraphQL/Concepts/ConceptAsTypeProvider.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dolittle.Vanir.Backend.Concepts;
+using HotChocolate.Utilities;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Concepts
+{
+    public class ConceptAsTypeProvider<TConcept> : IChangeTypeProvider
+        where TConcept : new()
+    {
+        public bool TryCreateConverter(Type source, Type target, ChangeTypeProvider root, [NotNullWhen(true)] out ChangeType converter)
+        {
+            if (source == typeof(TConcept))
+            {
+                var conceptValueType = source.GetConceptValueType();
+                if (source == typeof(TConcept) && target == conceptValueType)
+                {
+                    converter = (value) => value.GetConceptValue();
+                    return true;
+                }
+            }
+
+            if (target == typeof(TConcept))
+            {
+                var conceptValueType = target.GetConceptValueType();
+                if (source == conceptValueType && target == typeof(TConcept))
+                {
+                    converter = (value) => ConceptFactory.CreateConceptInstance(typeof(TConcept), value);
+                    return true;
+                }
+            }
+
+            converter = null;
+            return false;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/ObjectTypeExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/ObjectTypeExtensions.cs
@@ -9,13 +9,28 @@ using HotChocolate.Types;
 
 namespace Dolittle.Vanir.Backend.GraphQL
 {
+    /// <summary>
+    /// Extension methods for working with <see cref="IObjectTypeDescriptor{T}"/>.
+    /// </summary>
     public static class ObjectTypeExtensions
     {
+        /// <summary>
+        /// Add all query fields based on <see cref="QueryAttribute"/> of members of a given type.
+        /// </summary>
+        /// <param name="descriptor"><see cref="IObjectTypeDescriptor{T}"/> to add to.</param>
+        /// <param name="type"><see cref="Type"/> to add from</param>
+        /// <returns>Any field descriptors added</returns>
         public static IEnumerable<IObjectFieldDescriptor> AddQueryFields(this IObjectTypeDescriptor<Query> descriptor, Type type)
         {
             return descriptor.AddFieldsFor<Query, QueryAttribute>(type);
         }
 
+        /// <summary>
+        /// Add all query fields based on <see cref="MuttationAttribute"/> of members of a given type.
+        /// </summary>
+        /// <param name="descriptor"><see cref="IObjectTypeDescriptor{T}"/> to add to.</param>
+        /// <param name="type"><see cref="Type"/> to add from</param>
+        /// <returns>Any field descriptors added</returns>
         public static IEnumerable<IObjectFieldDescriptor> AddMutationFields(this IObjectTypeDescriptor<Mutation> descriptor, Type type)
         {
             return descriptor.AddFieldsFor<Mutation, MutationAttribute>(type);

--- a/Source/DotNET/Backend/Reflection/ITypeInfo.cs
+++ b/Source/DotNET/Backend/Reflection/ITypeInfo.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Dolittle.Vanir.Backend.Reflection
+{
+    /// <summary>
+    /// Defines information for types.
+    /// </summary>
+    public interface ITypeInfo
+    {
+        /// <summary>
+        /// Gets a value indicating whether or not the type has a default constructor that takes no arguments.
+        /// </summary>
+        bool HasDefaultConstructor { get; }
+    }
+}

--- a/Source/DotNET/Backend/Reflection/TypeConstructorExtensions.cs
+++ b/Source/DotNET/Backend/Reflection/TypeConstructorExtensions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Dolittle.Vanir.Backend.Reflection
+{
+    /// <summary>
+    /// Provides a set of methods for working with <see cref="Type">types</see> and their constructors.
+    /// </summary>
+    public static class TypeConstructorExtensions
+    {
+        /// <summary>
+        /// Check if a type has a default constructor that does not take any arguments.
+        /// </summary>
+        /// <param name="type">Type to check.</param>
+        /// <returns>true if it has a default constructor, false if not.</returns>
+        public static bool HasDefaultConstructor(this Type type)
+        {
+            return TypeExtensions.GetTypeInfo(type).HasDefaultConstructor ||
+                type.GetConstructors().Any(c => c.GetParameters().Length == 0);
+        }
+
+        /// <summary>
+        /// Check if a type has a non default constructor.
+        /// </summary>
+        /// <param name="type">Type to check.</param>
+        /// <returns>true if it has a non default constructor, false if not.</returns>
+        public static bool HasNonDefaultConstructor(this Type type)
+        {
+            return type.GetConstructors().Any(c => c.GetParameters().Length > 0);
+        }
+
+        /// <summary>
+        /// Get the default constructor from a type.
+        /// </summary>
+        /// <param name="type">Type to get from.</param>
+        /// <returns>The default <see cref="ConstructorInfo"/>.</returns>
+        public static ConstructorInfo GetDefaultConstructor(this Type type)
+        {
+            return type.GetConstructors().Single(c => c.GetParameters().Length == 0);
+        }
+
+        /// <summary>
+        /// Get the non default constructor, assuming there is only one.
+        /// </summary>
+        /// <param name="type">Type to get from.</param>
+        /// <returns>The <see cref="ConstructorInfo"/> for the constructor.</returns>
+        public static ConstructorInfo GetNonDefaultConstructor(this Type type)
+        {
+            return type.GetConstructors().Single(c => c.GetParameters().Length > 0);
+        }
+
+        /// <summary>
+        /// Get the non default constructor matching the types.
+        /// </summary>
+        /// <param name="type">Type to get from.</param>
+        /// <param name="parameterTypes">Types for matching the parameters.</param>
+        /// <returns>The <see cref="ConstructorInfo"/> for the constructor.</returns>
+        public static ConstructorInfo GetNonDefaultConstructor(this Type type, Type[] parameterTypes)
+        {
+            return type.GetTypeInfo().GetConstructor(parameterTypes);
+        }
+
+        /// <summary>
+        /// Get the non default constructor with the greatest number of parameters.
+        /// Should be used with care. Constructors are not ordered, so if there are multiple constructors with the
+        /// same number of parameters, it is indeterminate which will be returned.
+        /// </summary>
+        /// <param name="type">Type to get from.</param>
+        /// <returns>The <see cref="ConstructorInfo"/> for the constructor.</returns>
+        public static ConstructorInfo GetNonDefaultConstructorWithGreatestNumberOfParameters(this Type type)
+        {
+            return type.GetTypeInfo()
+                            .DeclaredConstructors.Where(c => c.GetParameters().Length > 0)
+                            .OrderByDescending((t) => t.GetParameters().Length)
+                            .FirstOrDefault();
+        }
+    }
+}

--- a/Source/DotNET/Backend/Reflection/TypeExtensions.cs
+++ b/Source/DotNET/Backend/Reflection/TypeExtensions.cs
@@ -13,6 +13,52 @@ namespace Dolittle.Vanir.Backend.Reflection
     /// </summary>
     public static class TypeExtensions
     {
+        static readonly HashSet<Type> _additionalPrimitiveTypes = new()
+        {
+            typeof(decimal),
+            typeof(string),
+            typeof(Guid),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan)
+        };
+
+        static readonly HashSet<Type> _numericTypes = new()
+        {
+            typeof(byte),
+            typeof(sbyte),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(ushort),
+            typeof(uint),
+            typeof(ulong),
+            typeof(double),
+            typeof(decimal),
+            typeof(float)
+        };
+
+        /// <summary>
+        /// Check if a type derives from an open generic type.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <param name="openGenericType">Open generic <see cref="Type"/> to check for.</param>
+        /// <returns>True if type matches the open generic <see cref="Type"/>.</returns>
+        public static bool IsDerivedFromOpenGeneric(this Type type, Type openGenericType)
+        {
+            var typeToCheck = type;
+            while (typeToCheck != null && typeToCheck != typeof(object))
+            {
+                var currentType = typeToCheck.GetTypeInfo().IsGenericType ? typeToCheck.GetGenericTypeDefinition() : typeToCheck;
+                if (openGenericType == currentType)
+                    return true;
+
+                typeToCheck = typeToCheck.GetTypeInfo().BaseType;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Returns all base types of a given type, both open and closed generic (if any), including itself.
         /// </summary>
@@ -24,6 +70,123 @@ namespace Dolittle.Vanir.Backend.Reflection
                 .Concat(type.GetTypeInfo().GetInterfaces())
                 .SelectMany(ThisAndMaybeOpenType)
                 .Where(t => t != type && t != typeof(object));
+        }
+
+        /// <summary>
+        /// Check if a type is nullable or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is nullable, false if not.</returns>
+        public static bool IsNullable(this Type type)
+        {
+            return type.GetTypeInfo().IsGenericType &&
+                   type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+
+        /// <summary>
+        /// Check if a type is a number or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is numeric, false if not.</returns>
+        public static bool IsNumericType(this Type type)
+        {
+            return _numericTypes.Contains(type) ||
+                   _numericTypes.Contains(Nullable.GetUnderlyingType(type));
+        }
+
+        /// <summary>
+        /// Check if a type is enumerable. Note that string is an IEnumerable, but in this case the string is excluded.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is enumerable, false if not an enumerable.</returns>
+        public static bool IsEnumerable(this Type type)
+        {
+            return !type.IsAPrimitiveType() && !type.IsString() && typeof(System.Collections.IEnumerable).IsAssignableFrom(type);
+        }
+
+        /// <summary>
+        /// Check if the type is of the type specified in the generic param.
+        /// </summary>
+        /// <typeparam name="T">Type of the instance.</typeparam>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a date, false if not.</returns>
+        public static bool Is<T>(this Type type)
+        {
+            return type == typeof(T) || Nullable.GetUnderlyingType(type) == typeof(T);
+        }
+
+        /// <summary>
+        /// Check if a type is a Date or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a date, false if not.</returns>
+        public static bool IsDate(this Type type)
+        {
+            return Is<DateTime>(type);
+        }
+
+        /// <summary>
+        /// Check if a type is a DateTimeOffset or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a date, false if not.</returns>
+        public static bool IsDateTimeOffset(this Type type)
+        {
+            return Is<DateTimeOffset>(type);
+        }
+
+        /// <summary>
+        /// Check if a type is a Boolean or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a boolean, false if not.</returns>
+        public static bool IsBoolean(this Type type)
+        {
+            return Is<bool>(type);
+        }
+
+        /// <summary>
+        /// Check if a type is a String or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a string, false otherwise.</returns>
+        public static bool IsString(this Type type)
+        {
+            return Is<string>(type);
+        }
+
+        /// <summary>
+        /// Check if a type is a Guid or not.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if type is a Guid, false otherwise.</returns>
+        public static bool IsGuid(this Type type)
+        {
+            return Is<Guid>(type);
+        }
+
+        /// <summary>
+        /// Check if a type is a "primitve" type.  This is not just dot net primitives but basic types like string, decimal, datetime,
+        /// that are not classified as primitive types.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to check.</param>
+        /// <returns>True if <see cref="Type"/> is a primitive type.</returns>
+        public static bool IsAPrimitiveType(this Type type)
+        {
+            return type.GetTypeInfo().IsPrimitive
+                    || type.IsNullable() || _additionalPrimitiveTypes.Contains(type);
+        }
+
+        /// <summary>
+        /// Get <see cref="ITypeInfo"/> from <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type"><see cref="Type"/> to get from.</param>
+        /// <returns>The <see cref="ITypeInfo"/>.</returns>
+        internal static ITypeInfo GetTypeInfo(Type type)
+        {
+            var typeInfoType = typeof(TypeInfo<>).MakeGenericType(type);
+            var instanceField = typeInfoType.GetTypeInfo().GetField("Instance", BindingFlags.Public | BindingFlags.Static);
+            return instanceField.GetValue(null) as ITypeInfo;
         }
 
         static IEnumerable<Type> BaseTypes(this Type type)

--- a/Source/DotNET/Backend/Reflection/TypeInfo.cs
+++ b/Source/DotNET/Backend/Reflection/TypeInfo.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Reflection;
+
+namespace Dolittle.Vanir.Backend.Reflection
+{
+    /// <summary>
+    /// Represents an implementation of <see cref="ITypeInfo"/>.
+    /// </summary>
+    /// <typeparam name="T">Type it holds info for.</typeparam>
+    public class TypeInfo<T> : ITypeInfo
+    {
+        /// <summary>
+        /// Gets a singleton instance of the TypeInfo.
+        /// </summary>
+        public static readonly TypeInfo<T> Instance = new();
+
+        TypeInfo()
+        {
+            var type = typeof(T);
+            var typeInfo = type.GetTypeInfo();
+
+            var defaultConstructor = typeInfo.DeclaredConstructors.Any(_ => _.GetParameters().Length == 0);
+
+            HasDefaultConstructor =
+                typeInfo.IsValueType ||
+                defaultConstructor;
+        }
+
+        /// <inheritdoc/>
+        public bool HasDefaultConstructor { get; }
+    }
+}


### PR DESCRIPTION
### Added

- ConceptAs extensions to make it easier to work with ConceptAs
- Reflection extensions to make it easier to work with type reflection
- Automatic hookup of Type conversion for GraphQL for ConceptAs and base type mapping. This enables use of concepts in any GraphQL construct (ObjectType) and it will map to the underlying system type it is a concept as of.

