### PR TITLE
graphql-validation

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -1,13 +1,28 @@
 using System;
+using Dolittle.SDK.Concepts;
 using Dolittle.Vanir.Backend.GraphQL;
 using FluentValidation;
 using MongoDB.Driver;
 
 namespace Backend
 {
+    public class SomeConcept : ConceptAs<string>
+    {
+    }
+
+    public class SomeConceptValidator : AbstractValidator<SomeConcept>
+    {
+        public SomeConceptValidator()
+        {
+            RuleFor(_ => _.Value).NotNull().NotEmpty().WithMessage("The string must have content");
+        }
+    }
+
     public class MyObject
     {
-        public string Something { get; set; }
+        public string Something { get; set; }
+        public int SomeNumber { get; set; }
+        public SomeConcept Concept { get; set; }
     }
 
     public class MyObjectValidator : AbstractValidator<MyObject>
@@ -15,9 +30,9 @@ namespace Backend
         public MyObjectValidator()
         {
             RuleFor(_ => _.Something).NotNull().NotEmpty().WithMessage("This should be set");
+            RuleFor(_ => _.SomeNumber).GreaterThan(42).WithMessage("Must be greater than 42");
         }
     }
-
 
     public class Things : GraphController
     {

--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -1,9 +1,24 @@
 using System;
 using Dolittle.Vanir.Backend.GraphQL;
+using FluentValidation;
 using MongoDB.Driver;
 
 namespace Backend
 {
+    public class MyObject
+    {
+        public string Something { get; set; }
+    }
+
+    public class MyObjectValidator : AbstractValidator<MyObject>
+    {
+        public MyObjectValidator()
+        {
+            RuleFor(_ => _.Something).NotNull().NotEmpty().WithMessage("This should be set");
+        }
+    }
+
+
     public class Things : GraphController
     {
         private readonly IMongoDatabase _mongoDatabase;
@@ -17,6 +32,13 @@ namespace Backend
         public bool DoSomething(OwnerId input)
         {
             Console.WriteLine($"Hello world - {input}");
+            return true;
+        }
+
+        [Mutation]
+        public bool DoThings(MyObject input)
+        {
+            Console.WriteLine($"Hello world - {input.Something}");
             return true;
         }
 

--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -10,6 +10,11 @@ namespace Backend
     {
     }
 
+    public class NestedObject
+    {
+        public SomeConcept DeepConcept { get; set; }
+    }
+
     public class SomeConceptValidator : AbstractValidator<SomeConcept>
     {
         public SomeConceptValidator()
@@ -23,6 +28,7 @@ namespace Backend
         public string Something { get; set; }
         public int SomeNumber { get; set; }
         public SomeConcept Concept { get; set; }
+        public NestedObject Nested { get; set; }
     }
 
     public class MyObjectValidator : AbstractValidator<MyObject>

--- a/Source/DotNET/Backend/Backend.csproj
+++ b/Source/DotNET/Backend/Backend.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="dolittle.sdk" Version="$(DolittleSdkVersion)" />
+        <PackageReference Include="FluentValidation" Version="9.5.3" />
         <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.9" />
         <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />

--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -7,7 +7,9 @@ using Dolittle.Vanir.Backend;
 using Dolittle.Vanir.Backend.Collections;
 using Dolittle.Vanir.Backend.GraphQL;
 using Dolittle.Vanir.Backend.GraphQL.Concepts;
+using Dolittle.Vanir.Backend.GraphQL.Validation;
 using Dolittle.Vanir.Backend.Reflection;
+using FluentValidation;
 using HotChocolate.Types;
 using HotChocolate.Types.Descriptors;
 
@@ -24,13 +26,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Add GraphQL services.
         /// </summary>
         /// <param name="services"><see cref="IServiceColletion"/> to add to.</param>
-        public static void AddGraphQL(this IServiceCollection services, BackendArguments arguments = null, ITypes types = null)
+        public static void AddGraphQL(this IServiceCollection services, IContainer container, BackendArguments arguments = null, ITypes types = null)
         {
             if (types == null)
             {
                 types = new Types();
                 services.Add(new ServiceDescriptor(typeof(ITypes), types));
             }
+
+            services.AddFluentValidation(container, types);
 
             var graphControllers = new GraphControllers(types);
             services.Add(new ServiceDescriptor(typeof(IGraphControllers), graphControllers));
@@ -42,6 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var graphQLBuilder = services
                                     .AddGraphQLServer()
+                                    .UseFluentValidation()
                                     .AddType(new UuidType(UuidFormat));
             types.FindMultiple<ScalarType>().Where(_ => !_.IsGenericType).ForEach(_ => graphQLBuilder.AddType(_));
 

--- a/Source/DotNET/Backend/GraphQL/Validation/IValidators.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/IValidators.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using FluentValidation;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Validation
+{
+    public interface IValidators
+    {
+        bool HasFor(Type type);
+        IValidator GetFor(Type type);
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationExtensions.cs
@@ -5,6 +5,7 @@ using Dolittle.Vanir.Backend.Collections;
 using Dolittle.Vanir.Backend.Reflection;
 using FluentValidation;
 using HotChocolate.Execution.Configuration;
+using HotChocolate.Types.Descriptors;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dolittle.Vanir.Backend.GraphQL.Validation

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Vanir.Backend.Collections;
+using Dolittle.Vanir.Backend.Reflection;
+using FluentValidation;
+using HotChocolate.Execution.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Validation
+{
+    public static class ValidationExtensions
+    {
+        public static IServiceCollection AddFluentValidation(this IServiceCollection services, IContainer container, ITypes types)
+        {
+            var validators = new Validators(types, container);
+            services.AddSingleton<IValidators>(validators);
+            validators.All.ForEach(_ => services.AddTransient(_));
+            return services;
+        }
+
+        public static IRequestExecutorBuilder UseFluentValidation(this IRequestExecutorBuilder builder)
+        {
+            builder.UseField<ValidationMiddleware>();
+            return builder;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dolittle.Vanir.Backend.Reflection;
+using FluentValidation;
+using FluentValidation.Results;
+using HotChocolate;
+using HotChocolate.Resolvers;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Validation
+{
+    public class ValidationMiddleware
+    {
+        readonly FieldDelegate _next;
+        readonly IValidators _validators;
+
+        public ValidationMiddleware(FieldDelegate next, IValidators validators)
+        {
+            _next = next;
+            _validators = validators;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context)
+        {
+            foreach (var argument in context.Field.Arguments)
+            {
+                if (_validators.HasFor(argument.RuntimeType))
+                {
+                    var validator = _validators.GetFor(argument.RuntimeType);
+                    var instance = context.CallGenericMethod<object, IMiddlewareContext, NameString>(_ => _.ArgumentValue<object>, argument.Name, argument.RuntimeType);
+                    var validationContextType = typeof(ValidationContext<>).MakeGenericType(argument.RuntimeType);
+                    var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
+                    var result = await validator.ValidateAsync(validationContext);
+                    if (!result.IsValid)
+                    {
+                        SetResult(context, result);
+                        return;
+                    }
+                }
+            }
+
+            await _next(context);
+        }
+
+        void SetResult(IMiddlewareContext context, ValidationResult result)
+        {
+            List<IError> errors = new();
+            foreach (var validationError in result.Errors)
+            {
+                errors.Add(ErrorBuilder.New()
+                .SetMessage(validationError.ErrorCode)
+                .SetExtension(validationError.PropertyName, validationError.ErrorMessage)
+                .SetPath(context.Path)
+                .Build());
+            }
+            context.Result = errors;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Dolittle.Vanir.Backend.Concepts;
 using Dolittle.Vanir.Backend.Reflection;
+using Dolittle.Vanir.Backend.Strings;
 using FluentValidation;
 using FluentValidation.Results;
 using HotChocolate;
@@ -80,6 +81,7 @@ namespace Dolittle.Vanir.Backend.GraphQL.Validation
                 {
                     propertyName = parentProperty.Name;
                 }
+                propertyName = propertyName.ToCamelCase();
                 errors.Add(ErrorBuilder.New()
                 .SetMessage(validationError.ErrorCode)
                 .SetExtension(propertyName, validationError.ErrorMessage)

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
@@ -12,7 +12,6 @@ using FluentValidation;
 using FluentValidation.Results;
 using HotChocolate;
 using HotChocolate.Resolvers;
-using HotChocolate.Types.Descriptors;
 
 namespace Dolittle.Vanir.Backend.GraphQL.Validation
 {
@@ -20,13 +19,11 @@ namespace Dolittle.Vanir.Backend.GraphQL.Validation
     {
         readonly FieldDelegate _next;
         readonly IValidators _validators;
-        readonly INamingConventions _namingConventions;
 
-        public ValidationMiddleware(FieldDelegate next, IValidators validators, INamingConventions namingConventions)
+        public ValidationMiddleware(FieldDelegate next, IValidators validators)
         {
             _next = next;
             _validators = validators;
-            _namingConventions = namingConventions;
         }
 
         public async Task InvokeAsync(IMiddlewareContext context)

--- a/Source/DotNET/Backend/GraphQL/Validation/Validators.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/Validators.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dolittle.Vanir.Backend.Reflection;
+using FluentValidation;
+
+namespace Dolittle.Vanir.Backend.GraphQL.Validation
+{
+    public class Validators : IValidators
+    {
+        readonly ITypes _types;
+        readonly IContainer _container;
+        readonly Dictionary<Type, Type> _validatorTypesByType = new();
+
+        public Validators(ITypes types, IContainer container)
+        {
+            _types = types;
+            _container = container;
+
+            var validatorTypes = _types.FindMultiple(typeof(AbstractValidator<>));
+            _validatorTypesByType = validatorTypes.ToDictionary(_ =>
+            {
+                var baseTypes = _.AllBaseAndImplementingTypes();
+                var type = baseTypes.Single(_ =>
+                {
+                    if (_.GenericTypeArguments.Length == 1)
+                    {
+                        return _ == typeof(AbstractValidator<>).MakeGenericType(_.GenericTypeArguments[0]);
+                    }
+
+                    return false;
+                });
+
+                return type.GenericTypeArguments[0];
+            }, _ => _);
+        }
+
+        public IEnumerable<Type> All => _validatorTypesByType.Values;
+
+        public bool HasFor(Type type)
+        {
+            return _validatorTypesByType.ContainsKey(type);
+        }
+
+        public IValidator GetFor(Type type)
+        {
+            return _container.Get(_validatorTypesByType[type]) as IValidator;
+        }
+    }
+}

--- a/Source/DotNET/Backend/Reflection/ContractToImplementorsMap.cs
+++ b/Source/DotNET/Backend/Reflection/ContractToImplementorsMap.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 namespace Dolittle.Vanir.Backend.Reflection
 {
+
     /// <summary>
     /// Represents an implementation of <see cref="IContractToImplementorsMap"/>.
     /// </summary>

--- a/Source/DotNET/Backend/Reflection/ExpressionExtensions.cs
+++ b/Source/DotNET/Backend/Reflection/ExpressionExtensions.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Dolittle.Vanir.Backend.Reflection
+{
+
+    /// <summary>
+    /// Provides methods for working with expressions.
+    /// </summary>
+    public static class ExpressionExtensions
+    {
+        /// <summary>
+        /// A Func to extract a member expression from an Expression.
+        /// </summary>
+        public static Func<Expression, MemberExpression> Unwrap = (Func<Expression, MemberExpression>)(toUnwrap =>
+        {
+            if (toUnwrap is UnaryExpression unwrap)
+                return unwrap.Operand as MemberExpression;
+
+            return toUnwrap as MemberExpression;
+        });
+
+        /// <summary>
+        /// Get <see cref="MethodInfo">MethodInfo</see> from an <see cref="Expression">expression</see> - if any.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get MethodInfo from.</param>
+        /// <returns>The <see cref="MethodInfo">MethodInfo</see> found, null if did not find one.</returns>
+        public static MethodInfo GetMethodInfo(this Expression expression)
+        {
+            if (expression is LambdaExpression lambda &&
+                lambda.Body is MethodCallExpression)
+            {
+                var methodCall = lambda.Body as MethodCallExpression;
+                return methodCall.Method;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get all argument instances from a method expression.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression"/> to get argument instances from.</param>
+        /// <returns>Array of argument instances.</returns>
+        public static object[] GetMethodArguments(this Expression expression)
+        {
+            if (expression is LambdaExpression lambda &&
+                lambda.Body is MethodCallExpression)
+            {
+                var methodCall = lambda.Body as MethodCallExpression;
+                var arguments = new List<object>();
+
+                foreach (var argument in methodCall.Arguments)
+                {
+                    var member = argument as MemberExpression;
+                    var value = member.GetInstance();
+                    arguments.Add(value);
+                }
+
+                return arguments.ToArray();
+            }
+
+            return Array.Empty<object>();
+        }
+
+        /// <summary>
+        /// Get <see cref="MemberExpression">MemberExpression</see> from an <see cref="Expression">expression</see> - if any.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get <see cref="MemberExpression">MemberExpression</see> from.</param>
+        /// <returns><see cref="MemberExpression">MemberExpression</see> instance, null if there is none.</returns>
+        public static MemberExpression GetMemberExpression(this Expression expression)
+        {
+            var lambda = expression as LambdaExpression;
+            if (lambda.Body is UnaryExpression)
+            {
+                var unaryExpression = lambda.Body as UnaryExpression;
+                return unaryExpression.Operand as MemberExpression;
+            }
+            else
+            {
+                return lambda.Body as MemberExpression;
+            }
+        }
+
+        /// <summary>
+        /// Get <see cref="FieldInfo">FieldInfo</see> from an <see cref="Expression">Expression</see> - if any.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get <see cref="FieldInfo">FieldInfo</see> from.</param>
+        /// <returns><see cref="FieldInfo">FieldInfo</see> instance, null if there is none.</returns>
+        public static FieldInfo GetFieldInfo(this Expression expression)
+        {
+            var memberExpression = GetMemberExpression(expression);
+            return memberExpression.Member as FieldInfo;
+        }
+
+        /// <summary>
+        /// Get <see cref="PropertyInfo">PropertyInfo</see> from an <see cref="Expression">Expression</see> - if any.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get <see cref="PropertyInfo">PropertyInfo</see> from.</param>
+        /// <returns><see cref="PropertyInfo">PropertyInfo</see> instance, null if there is none.</returns>
+        public static PropertyInfo GetPropertyInfo(this Expression expression)
+        {
+            var memberExpression = GetMemberExpression(expression);
+            return memberExpression.Member as PropertyInfo;
+        }
+
+        /// <summary>
+        /// Get an instance reference from an <see cref="Expression">Expression</see> - if any.
+        /// </summary>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get an instance from.</param>
+        /// <returns>The instance, null if there is none.</returns>
+        public static object GetInstance(this Expression expression)
+        {
+            var memberExpression = GetMemberExpression(expression);
+            return GetInstance(memberExpression);
+        }
+
+        /// <summary>
+        /// Get an instance reference from an <see cref="Expression">Expression</see>, with a specific type - if any.
+        /// </summary>
+        /// <typeparam name="T">Type of the instance.</typeparam>
+        /// <param name="expression"><see cref="Expression">Expression</see> to get an instance from.</param>
+        /// <returns>The instance, null if there is none.</returns>
+        public static T GetInstance<T>(this Expression expression)
+        {
+            return (T)GetInstance(expression);
+        }
+
+        static object GetInstance(this MemberExpression memberExpression)
+        {
+            if (!(memberExpression.Expression is ConstantExpression constantExpression))
+            {
+                var innerMember = memberExpression.Expression as MemberExpression;
+                if (innerMember.Member is FieldInfo info)
+                    return info.GetValue(null);
+
+                constantExpression = innerMember.Expression as ConstantExpression;
+                return GetValue(innerMember, constantExpression);
+            }
+
+            return GetValue(memberExpression, constantExpression);
+        }
+
+        static object GetValue(MemberExpression memberExpression, ConstantExpression constantExpression)
+        {
+            if (memberExpression.Member is PropertyInfo propertyInfo)
+                return propertyInfo.GetValue(constantExpression.Value, null);
+
+            if (memberExpression.Member is FieldInfo fieldInfo)
+                return fieldInfo.GetValue(constantExpression.Value);
+
+            return constantExpression.Value;
+        }
+    }
+}

--- a/Source/DotNET/Backend/Reflection/MethodCalls.cs
+++ b/Source/DotNET/Backend/Reflection/MethodCalls.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Dolittle.Vanir.Backend.Reflection
+{
+    /// <summary>
+    /// Extension methods for calling methods on objects using reflection.
+    /// </summary>
+    public static class MethodCalls
+    {
+        /// <summary>
+        /// Call generic method method.
+        /// </summary>
+        /// <param name="target">Target to call method on.</param>
+        /// <param name="method">Signature of the method.</param>
+        /// <param name="param1">First parameter.</param>
+        /// <param name="param2">Second parameter.</param>
+        /// <param name="param3">Third parameter.</param>
+        /// <param name="genericArguments">Generic arguments.</param>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="T">Type of target.</typeparam>
+        /// <typeparam name="T1">Type of first parameter.</typeparam>
+        /// <typeparam name="T2">Type of second parameter.</typeparam>
+        /// <typeparam name="T3">Type of third parameter.</typeparam>
+        /// <returns>The result from the method call.</returns>
+        public static TOut CallGenericMethod<TOut, T, T1, T2, T3>(this T target, Expression<Func<T, Func<T1, T2, T3, TOut>>> method, T1 param1, T2 param2, T3 param3, params Type[] genericArguments)
+        {
+            return CallGenericMethod<T, TOut>(target, method, new object[] { param1, param2, param3 }, genericArguments);
+        }
+
+        /// <summary>
+        /// Call generic method method.
+        /// </summary>
+        /// <param name="target">Target to call method on.</param>
+        /// <param name="method">Signature of the method.</param>
+        /// <param name="param1">First parameter.</param>
+        /// <param name="param2">Second parameter.</param>
+        /// <param name="genericArguments">Generic arguments.</param>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="T">Type of target.</typeparam>
+        /// <typeparam name="T1">Type of first parameter.</typeparam>
+        /// <typeparam name="T2">Type of second parameter.</typeparam>
+        /// <returns>The result from the method call.</returns>
+        public static TOut CallGenericMethod<TOut, T, T1, T2>(this T target, Expression<Func<T, Func<T1, T2, TOut>>> method, T1 param1, T2 param2, params Type[] genericArguments)
+        {
+            return CallGenericMethod<T, TOut>(target, method, new object[] { param1, param2 }, genericArguments);
+        }
+
+        /// <summary>
+        /// Call generic method method.
+        /// </summary>
+        /// <param name="target">Target to call method on.</param>
+        /// <param name="method">Signature of the method.</param>
+        /// <param name="param">Method parameter.</param>
+        /// <param name="genericArguments">Generic arguments.</param>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="T">Type of target.</typeparam>
+        /// <typeparam name="T1">Type of parameter.</typeparam>
+        /// <returns>The result from the method call.</returns>
+        public static TOut CallGenericMethod<TOut, T, T1>(this T target, Expression<Func<T, Func<T1, TOut>>> method, T1 param, params Type[] genericArguments)
+        {
+            return CallGenericMethod<T, TOut>(target, method, new object[] { param }, genericArguments);
+        }
+
+        /// <summary>
+        /// Call generic method method.
+        /// </summary>
+        /// <param name="target">Target to call method on.</param>
+        /// <param name="method">Signature of the method.</param>
+        /// <param name="genericArguments">Generic arguments.</param>
+        /// <typeparam name="TOut">Output type.</typeparam>
+        /// <typeparam name="T">Type of target.</typeparam>
+        /// <returns>The result from the method call.</returns>
+        public static TOut CallGenericMethod<TOut, T>(this T target, Expression<Func<T, Func<TOut>>> method, params Type[] genericArguments)
+        {
+            return CallGenericMethod<T, TOut>(target, method, Array.Empty<object>(), genericArguments);
+        }
+
+        static TOut CallGenericMethod<T, TOut>(this T target, Expression method, object[] parameters, Type[] genericArguments)
+        {
+            var lambda = method as LambdaExpression;
+            var unary = lambda.Body as UnaryExpression;
+            var methodCall = unary.Operand as MethodCallExpression;
+            var constant = methodCall.Object as ConstantExpression;
+
+            var methodInfo = constant.Value as MethodInfo;
+            var genericMethodDefinition = methodInfo.GetGenericMethodDefinition();
+
+            var genericMethod = genericMethodDefinition.MakeGenericMethod(genericArguments);
+
+            var result = genericMethod.Invoke(target, parameters);
+            return (TOut)result;
+        }
+    }
+}

--- a/Source/DotNET/Backend/Strings/StringExtensions.cs
+++ b/Source/DotNET/Backend/Strings/StringExtensions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+#pragma warning disable CA1308
+
+namespace Dolittle.Vanir.Backend.Strings
+{
+    /// <summary>
+    /// Provides a set of extension methods to <see cref="string"/>.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Convert a string into a camel cased string.
+        /// </summary>
+        /// <param name="stringToConvert">string to convert.</param>
+        /// <returns>Converted string.</returns>
+        public static string ToCamelCase(this string stringToConvert)
+        {
+            if (!string.IsNullOrEmpty(stringToConvert))
+            {
+                if (stringToConvert.Length == 1)
+                    return stringToConvert.ToLowerInvariant();
+
+                var firstLetter = stringToConvert[0].ToString(CultureInfo.InvariantCulture).ToLowerInvariant();
+                return $"{firstLetter}{stringToConvert.Substring(1)}";
+            }
+
+            return stringToConvert;
+        }
+
+        /// <summary>
+        /// Convert a string into a pascal cased string.
+        /// </summary>
+        /// <param name="stringToConvert">string to convert.</param>
+        /// <returns>Converted string.</returns>
+        public static string ToPascalCase(this string stringToConvert)
+        {
+            if (!string.IsNullOrEmpty(stringToConvert))
+            {
+                if (stringToConvert.Length == 1)
+                    return stringToConvert.ToUpperInvariant();
+
+                var firstLetter = stringToConvert[0].ToString(CultureInfo.InvariantCulture).ToUpperInvariant();
+                return $"{firstLetter}{stringToConvert.Substring(1)}";
+            }
+
+            return stringToConvert;
+        }
+    }
+}
+
+#pragma warning restore CA1308

--- a/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static void AddVanir(this IServiceCollection services, BackendArguments arguments = null)
         {
-            services.Add(new ServiceDescriptor(typeof(IContainer), typeof(Container), ServiceLifetime.Singleton));
+            var container = new Container();
+            services.AddSingleton<IContainer>(container);
             var types = new Types();
             services.Add(new ServiceDescriptor(typeof(ITypes), types));
 
             var configuration = services.AddVanirConfiguration();
-            services.AddGraphQL(arguments, types);
+            services.AddGraphQL(container, arguments, types);
 
             services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);
 


### PR DESCRIPTION
### Added

- `GraphRoot` attribute that will enable you to set the root object - can be nested, delimited by /
- `Query` attribute now supports path relative to `GraphRoot` or root if not `GraphRoot` is used - can be nested, delimited by /
- `Mutation` attribute now supports path relative to `GraphRoot` or root if not `GraphRoot` is used - can be nested, delimited by /
- Support for FluentValidations AbstractValidator - automatically hooked up on any input arguments
- AbstractValidator<> can be for any type - any input type with a property of a type with a validator will be evaluated as well