### PR TITLE
Making sure we don't get duplicate errors and correct for concepts

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -37,6 +37,7 @@ namespace Backend
         {
             RuleFor(_ => _.Something).NotNull().NotEmpty().WithMessage("This should be set");
             RuleFor(_ => _.SomeNumber).GreaterThan(42).WithMessage("Must be greater than 42");
+            RuleFor(_ => _.Concept).SetValidator(new SomeConceptValidator());
         }
     }
 


### PR DESCRIPTION
### Fixed

- Removes ".Value" for concepts being set using .SetValidator typically
- Does not add errors that are already there - avoids duplicate error messages for same proprty if one has added multiple instances of same validator
