### PR TITLE
Returning service(s) setup by AddVanir()

### DIFF
--- a/Source/DotNET/Backend/Services.cs
+++ b/Source/DotNET/Backend/Services.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Vanir.Backend.Reflection;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public class Services
+    {
+        public ITypes Types { get; init; }
+    }
+}

--- a/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class VanirServiceCollectionExtension
     {
-        public static void AddVanir(this IServiceCollection services, BackendArguments arguments = null)
+        public static Services AddVanir(this IServiceCollection services, BackendArguments arguments = null)
         {
             var container = new Container();
             services.AddSingleton<IContainer>(container);
@@ -24,6 +24,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddControllers();
             services.AddSwaggerGen();
             services.AddResources();
+
+            return new Services { Types = types };
         }
     }
 }


### PR DESCRIPTION
### Added

- `AddVanir()` now returns a `Services` object that holds for now the `ITypes` for type discovery but can then be expanded on in the future.
