### PR TITLE
Extending GraphQL schame with events and all the event types discovered

### DIFF
--- a/Source/DotNET/Backend/Dolittle/DolittleEventMutationsExtensions.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleEventMutationsExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Reflection;
+using Dolittle.SDK.Events;
+using Dolittle.Vanir.Backend.GraphQL;
+using Dolittle.Vanir.Backend.Reflection;
+using Dolittle.Vanir.Backend.Strings;
+
+namespace Dolittle.Vanir.Backend.Dolittle
+{
+    public static class DolittleEventMutationsExtensions
+    {
+        public static void AddEventsAsMutations(this SchemaRoute mutations, ITypes types)
+        {
+            var eventTypes = types.All.Where(_ => _.HasAttribute<EventTypeAttribute>());
+            if (eventTypes.Any())
+            {
+                var events = new SchemaRoute("events", "events", "_events");
+                mutations.AddChild(events);
+                foreach (var eventType in eventTypes)
+                {
+                    var mutationType = typeof(EventMutationFor<>).MakeGenericType(eventType);
+                    var method = mutationType.GetMethod("Commit", BindingFlags.Public | BindingFlags.Instance);
+                    var @event = new SchemaRouteItem(method, eventType.Name.ToCamelCase());
+                    events.AddItem(@event);
+                }
+            }
+        }
+    }
+}

--- a/Source/DotNET/Backend/Dolittle/EventMutationFor.cs
+++ b/Source/DotNET/Backend/Dolittle/EventMutationFor.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.SDK.Events.Store;
+
+namespace Dolittle.Vanir.Backend.Dolittle
+{
+    public class EventMutationFor<T>
+    {
+        readonly IEventStore _eventStore;
+
+        public EventMutationFor(IEventStore eventStore)
+        {
+            _eventStore = eventStore;
+        }
+
+        public async Task<int> Commit(Guid eventSourceId, T @event)
+        {
+            var committedEvents = await _eventStore.CommitEvent(@event, eventSourceId);
+            if (committedEvents.HasEvents)
+            {
+                var committedEvent = committedEvents.Single();
+                return (int)committedEvent.EventLogSequenceNumber.Value;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/GraphQLBuilderExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLBuilderExtensions.cs
@@ -29,9 +29,15 @@ namespace Dolittle.Vanir.Backend.GraphQL
             return builder;
         }
 
+
         public static IRequestExecutorBuilder AddMutations(this IRequestExecutorBuilder builder, IGraphControllers graphControllers, INamingConventions namingConventions)
         {
-            var mutation = BuildSchemaRoutesWithItems<MutationAttribute>("Mutation", graphControllers, namingConventions);
+            return builder.AddMutations(graphControllers, namingConventions, out _);
+        }
+
+        public static IRequestExecutorBuilder AddMutations(this IRequestExecutorBuilder builder, IGraphControllers graphControllers, INamingConventions namingConventions, out SchemaRoute mutation)
+        {
+            mutation = BuildSchemaRoutesWithItems<MutationAttribute>("Mutation", graphControllers, namingConventions);
             builder.AddMutationType(mutation);
             return builder;
         }

--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Dolittle.SDK.Concepts;
 using Dolittle.Vanir.Backend;
 using Dolittle.Vanir.Backend.Collections;
+using Dolittle.Vanir.Backend.Dolittle;
 using Dolittle.Vanir.Backend.GraphQL;
 using Dolittle.Vanir.Backend.GraphQL.Concepts;
 using Dolittle.Vanir.Backend.GraphQL.Validation;
@@ -54,7 +55,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             graphQLBuilder
                 .AddQueries(graphControllers, namingConventions)
-                .AddMutations(graphControllers, namingConventions);
+                .AddMutations(graphControllers, namingConventions, out SchemaRoute mutations);
+
+            mutations.AddEventsAsMutations(types);
 
             types.FindMultiple(typeof(ConceptAs<>)).ForEach(_ => graphQLBuilder.AddConceptTypeConverter(_));
 


### PR DESCRIPTION
### Added

- Exposing all event types based on types discovered into the GraphQL schema under mutation. Names are linked to the typename. This allowes for `mutation { events { ...nameOfEventType } }`

