### PR TITLE
Only add event mutations when in development mode

### DIFF
--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -57,8 +57,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddQueries(graphControllers, namingConventions)
                 .AddMutations(graphControllers, namingConventions, out SchemaRoute mutations);
 
-            mutations.AddEventsAsMutations(types);
-
             types.FindMultiple(typeof(ConceptAs<>)).ForEach(_ => graphQLBuilder.AddConceptTypeConverter(_));
 
             services.AddSingleton<INamingConventions>(namingConventions);
@@ -67,6 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (RuntimeEnvironment.isDevelopment)
             {
+                mutations.AddEventsAsMutations(types);
                 graphQLBuilder.AddApolloTracing();
             }
         }


### PR DESCRIPTION
### Fixed

- Event mutations should only be exposed when running in development
