### PR TITLE
Postfixing types resolved from routes with its type (Queries / Mutations)

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/GroceryStore/Bakery/BakeryController.cs
+++ b/Samples/Source/Aspnetcore/Backend/GroceryStore/Bakery/BakeryController.cs
@@ -7,10 +7,17 @@ namespace Backend.GroceryStore.Bakery
     [GraphRoot("groceryStore/bakery")]
     public class BakeryController : GraphController
     {
+        [Mutation("pastries/search")]
+        public async Task<bool> BuyPastry(string nameLike)
+        {
+            await Task.CompletedTask;
+            return true;
+        }
+
         [Query("pastries/search")]
         public async Task<IEnumerable<Danish>> SearchPastries(string nameLike)
         {
-            await Task.CompletedTask.ConfigureAwait(false);
+            await Task.CompletedTask;
 
             return new Danish[] {
                 new Danish()
@@ -20,7 +27,7 @@ namespace Backend.GroceryStore.Bakery
         [Query("pastries/recipe")]
         public async Task<Recipe> RetrieveRecipe(RecipeId id)
         {
-            await Task.CompletedTask.ConfigureAwait(false);
+            await Task.CompletedTask;
 
             return new Recipe();
         }
@@ -28,7 +35,7 @@ namespace Backend.GroceryStore.Bakery
         [Query("breadCounter/orders")]
         public async Task<IEnumerable<BreadOrder>> FindOrders(OrderId id)
         {
-            await Task.CompletedTask.ConfigureAwait(false);
+            await Task.CompletedTask;
 
             return new BreadOrder[] {
                 new BreadOrder()


### PR DESCRIPTION
### Fixed

- Enabling queries and mutations to live on the same route by postfixing the types used within Query and Mutation types and their children. Postifxes are "Queries" and "Mutations" for the types.
