### PR TITLE
aggregate-roots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "console": "internalConsole"
         },
         {
-            "name": "Launch Basic Sample",
+            "name": "Launch TypeScript Sample",
             "type": "node",
             "request": "launch",
             "runtimeExecutable": "node",

--- a/Samples/.dolittle/Typescript/resources.json
+++ b/Samples/.dolittle/Typescript/resources.json
@@ -1,5 +1,5 @@
 {
-    "508c1745-5f2a-4b4c-b7a5-2fbb1484346d": {
+    "445f8ea8-1a6f-40d7-b2fc-796dba92dc44": {
         "eventStore": {
             "servers": [
                 "sampleapp-mongo"

--- a/Samples/.dolittle/docker-compose.yml
+++ b/Samples/.dolittle/docker-compose.yml
@@ -1,8 +1,6 @@
 version: '3.1'
 services:
   sampleapp-mongo:
-    logging:
-        driver: none
     labels:
       - dolittle="77628df0-f46f-2e46-87a6-bc5a75578bcf"
     image: dolittle/mongodb:4.2.2
@@ -10,8 +8,6 @@ services:
       - 27017:27017
 
   sampleapp-ingress:
-    logging:
-        driver: none
     labels:
       - dolittle="77628df0-f46f-2e46-87a6-bc5a75578bcf"
     image: nginx:1.18.0
@@ -24,7 +20,7 @@ services:
   sampleapp-runtime-portal:
     labels:
       - dolittle="77628df0-f46f-2e46-87a6-bc5a75578bcf"
-    image: dolittle/runtime:5.4.2
+    image: dolittle/runtime:5.5.0
     volumes:
       - ./Portal/resources.json:/app/.dolittle/resources.json
       - ./tenants.json:/app/.dolittle/tenants.json
@@ -38,7 +34,7 @@ services:
   sampleapp-runtime-aspnetcore:
     labels:
       - dolittle="77628df0-f46f-2e46-87a6-bc5a75578bcf"
-    image: dolittle/runtime:5.4.2
+    image: dolittle/runtime:5.5.0
     volumes:
       - ./AspNetCore/resources.json:/app/.dolittle/resources.json
       - ./tenants.json:/app/.dolittle/tenants.json
@@ -52,7 +48,7 @@ services:
   sampleapp-runtime-typescript:
     labels:
       - dolittle="77628df0-f46f-2e46-87a6-bc5a75578bcf"
-    image: dolittle/runtime:5.4.2
+    image: dolittle/runtime:5.5.0
     volumes:
       - ./Typescript/resources.json:/app/.dolittle/resources.json
       - ./tenants.json:/app/.dolittle/tenants.json

--- a/Samples/.dolittle/nginx.conf
+++ b/Samples/.dolittle/nginx.conf
@@ -47,7 +47,7 @@ http {
         }
 
         location /_/aspnetcore/graphql {
-            proxy_pass http://host.docker.internal:5000;
+            proxy_pass http://host.docker.internal:3002;
             proxy_set_header Host localhost:9000;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header User-ID 2b0edb29-4051-40ea-95d4-2f5a8c2e6b16;
@@ -55,7 +55,7 @@ http {
         }
 
         location /api/aspnetcore {
-            proxy_pass http://host.docker.internal:5000;
+            proxy_pass http://host.docker.internal:3002;
             proxy_set_header Host localhost:9000;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header User-ID 2b0edb29-4051-40ea-95d4-2f5a8c2e6b16;

--- a/Source/typescript/backend/BackendArguments.ts
+++ b/Source/typescript/backend/BackendArguments.ts
@@ -9,7 +9,8 @@ import swaggerUI from 'swagger-ui-express';
 export interface BackendArguments {
     graphQLResolvers?: Constructor[];
     swaggerDoc?: swaggerUI.JsonObject;
-
+    eventTypes?: Constructor[];
+    eventHandlerTypes?: Constructor[];
     expressCallback?: ExpressConfigCallback;
     dolittleCallback?: DolittleClientBuilderCallback;
 }

--- a/Source/typescript/backend/Host.ts
+++ b/Source/typescript/backend/Host.ts
@@ -34,7 +34,7 @@ export class Host {
 
             MongoDb.initialize();
             await Resources.initialize();
-            await Dolittle.initialize(configuration, startArguments.dolittleCallback);
+            await Dolittle.initialize(configuration, startArguments);
             await Express.initialize(configuration, startArguments.graphQLResolvers, startArguments.swaggerDoc, startArguments.expressCallback);
         });
     }

--- a/Source/typescript/backend/aggregates/Aggregate.ts
+++ b/Source/typescript/backend/aggregates/Aggregate.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRoot, IAggregateRootOperations } from '@dolittle/sdk.aggregates';
+import { injectable } from 'tsyringe';
+import { Constructor } from '@dolittle/types';
+import { IAggregate } from './IAggregate';
+import { EventSourceId, CommittedAggregateEvent, CommittedAggregateEvents, EventTypeId } from '@dolittle/sdk.events';
+import { AggregateRootOperations, AggregateRootDecoratedTypes, OnDecoratedMethod, OnDecoratedMethods } from '@dolittle/sdk.aggregates';
+import { AggregateRootVersionIsOutOfOrder, EventWasAppliedByOtherAggregateRoot, EventWasAppliedToOtherEventSource } from '@dolittle/sdk.events'
+import { Guid } from '@dolittle/rudiments';
+import { ILogger } from '../logging/ILogger';
+import { IEventTypes, IEventStore } from '../dolittle';
+import { Logger } from 'winston';
+
+@injectable()
+export class Aggregate implements IAggregate {
+    constructor(private readonly _eventStore: IEventStore, private readonly _eventTypes: IEventTypes, private readonly _logger: ILogger) { }
+
+    async of<TAggregate extends AggregateRoot>(type: Constructor<TAggregate>, eventSourceId: EventSourceId | Guid | string): Promise<IAggregateRootOperations<TAggregate>> {
+        eventSourceId = EventSourceId.from(eventSourceId as any);
+        const aggregateRoot = new type(eventSourceId);
+        const aggregateRootId = AggregateRootDecoratedTypes.getFor(type).aggregateRootId;
+        (aggregateRoot as any).aggregateRootId = aggregateRootId;
+
+        this._logger.debug(
+            `Re-applying events for ${type.name} with aggregate root id ${aggregateRootId} with event source id ${eventSourceId}`,
+            type,
+            aggregateRootId,
+            eventSourceId
+        );
+
+        const committedEvents = await this._eventStore.fetchForAggregate(aggregateRootId, eventSourceId);
+        if (committedEvents.hasEvents) {
+            this._logger.silly(`Re-applying ${committedEvents.length}`, committedEvents.length);
+            this.throwIfEventWasAppliedToOtherEventSource(aggregateRoot, committedEvents);
+            this.throwIfEventWasAppliedByOtherAggreateRoot(aggregateRoot, committedEvents);
+
+            let onMethods: OnDecoratedMethod[] = [];
+            const hasState = OnDecoratedMethods.methodsPerAggregate.has(type);
+            if (hasState) {
+                onMethods = OnDecoratedMethods.methodsPerAggregate.get(type)!;
+            }
+
+            for (const event of committedEvents) {
+                this.throwIfAggregateRootVersionIsOutOfOrder(aggregateRoot, event);
+                aggregateRoot.nextVersion();
+                if (hasState) {
+                    const onMethod = onMethods.find(_ => {
+                        let eventTypeId = EventTypeId.from(Guid.empty);
+                        if (_.eventTypeOrId instanceof Function) {
+                            eventTypeId = this._eventTypes.getFor(_.eventTypeOrId).id;
+                        } else {
+                            eventTypeId = EventTypeId.from(_.eventTypeOrId);
+                        }
+
+                        return eventTypeId.equals(event.type.id);
+                    });
+
+                    if (onMethod) {
+                        onMethod.method.call(aggregateRoot, event.content);
+                    }
+                }
+            }
+        } else {
+            this._logger.silly('No events to re-apply');
+        }
+
+        const operations = new AggregateRootOperations<TAggregate>(
+            type,
+            this._eventStore,
+            aggregateRoot,
+            this._eventTypes,
+            this._logger as Logger);
+        return operations;
+
+    }
+
+    private throwIfAggregateRootVersionIsOutOfOrder(aggregateRoot: AggregateRoot, event: CommittedAggregateEvent) {
+        if (event.aggregateRootVersion.value !== aggregateRoot.version.value) {
+            throw new AggregateRootVersionIsOutOfOrder(event.aggregateRootVersion, aggregateRoot.version);
+        }
+    }
+
+    private throwIfEventWasAppliedByOtherAggreateRoot(aggregateRoot: AggregateRoot, event: CommittedAggregateEvents) {
+        if (!event.aggregateRootId.equals(aggregateRoot.aggregateRootId)) {
+            throw new EventWasAppliedByOtherAggregateRoot(event.aggregateRootId, aggregateRoot.aggregateRootId);
+        }
+    }
+
+    private throwIfEventWasAppliedToOtherEventSource(aggregateRoot: AggregateRoot, event: CommittedAggregateEvents) {
+        if (!event.eventSourceId.equals(aggregateRoot.eventSourceId)) {
+            throw new EventWasAppliedToOtherEventSource(event.eventSourceId, aggregateRoot.eventSourceId);
+        }
+    }
+
+}

--- a/Source/typescript/backend/aggregates/Aggregate.ts
+++ b/Source/typescript/backend/aggregates/Aggregate.ts
@@ -1,13 +1,28 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { AggregateRoot, IAggregateRootOperations } from '@dolittle/sdk.aggregates';
 import { injectable } from 'tsyringe';
 import { Constructor } from '@dolittle/types';
 import { IAggregate } from './IAggregate';
-import { EventSourceId, CommittedAggregateEvent, CommittedAggregateEvents, EventTypeId } from '@dolittle/sdk.events';
-import { AggregateRootOperations, AggregateRootDecoratedTypes, OnDecoratedMethod, OnDecoratedMethods } from '@dolittle/sdk.aggregates';
-import { AggregateRootVersionIsOutOfOrder, EventWasAppliedByOtherAggregateRoot, EventWasAppliedToOtherEventSource } from '@dolittle/sdk.events'
+import {
+    AggregateRootVersionIsOutOfOrder,
+    EventWasAppliedByOtherAggregateRoot,
+    EventWasAppliedToOtherEventSource,
+    EventSourceId,
+    CommittedAggregateEvent,
+    CommittedAggregateEvents,
+    EventTypeId
+} from '@dolittle/sdk.events';
+
+import {
+    AggregateRoot,
+    IAggregateRootOperations,
+    AggregateRootOperations,
+    AggregateRootDecoratedTypes,
+    OnDecoratedMethod,
+    OnDecoratedMethods
+} from '@dolittle/sdk.aggregates';
+
 import { Guid } from '@dolittle/rudiments';
 import { ILogger } from '../logging/ILogger';
 import { IEventTypes, IEventStore } from '../dolittle';

--- a/Source/typescript/backend/aggregates/BrokenRule.ts
+++ b/Source/typescript/backend/aggregates/BrokenRule.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/**
+ * The exception that is thrown as the consequence of a broken rule
+ */
+export class BrokenRuleError extends Error {
+    constructor(readonly source: string, readonly rule: BrokenRule, message: string) {
+        super(message);
+    }
+}
+
+/**
+ * Represents a broken rule in the system
+ */
+export class BrokenRule {
+    constructor(readonly name: string, readonly message: string) {
+    }
+
+    /**
+     * Create a broken rule
+     * @param {string} name Name of the rule
+     * @param {string} message Message to show - can include {argName} type of arguments for string interpolation
+     * @returns {BrokenRule}
+     */
+    static create(name: string, message: string): BrokenRule {
+        return new BrokenRule(name, message);
+    }
+
+    /**
+     * Fail with the broken rule
+     * @param {any | string} argsOrMessage Arguments or concrete message to fail with.
+     * @param {string?} source Optional string containing the source.
+     */
+    fail(argsOrMessage: any | string, source: string = 'unknown') {
+        let message = this.message;
+        if (argsOrMessage) {
+            if (argsOrMessage instanceof String) {
+                message = message;
+            } else {
+                message = this.interpolateString(this.message, argsOrMessage);
+            }
+        }
+
+        throw new BrokenRuleError(source, this, message);
+    }
+
+    private interpolateString(input: string, args: any): string {
+        const regex = new RegExp('{(.*?)}', '\g');
+        let result = input;
+        const argumentKeys = Object.keys(args);
+
+        input.match(regex)?.forEach(match => {
+            const toReplace = match;
+            const key = toReplace.substr(1, toReplace.length - 2);
+
+            if (argumentKeys.some(_ => _ === key)) {
+                const value = args[key];
+                result = result.split(toReplace).join(value);
+            }
+        });
+
+        return result;
+    }
+}
+
+import { AggregateRoot } from '@dolittle/sdk.aggregates';
+
+declare module '@dolittle/sdk.aggregates' {
+    interface AggregateRoot {
+        /**
+         * Fail with a broken rule for the aggregate.
+         * @param {BrokenRule} rule Rule to fail
+         * @param {any | string} argsOrMessage Arguments or concrete message to fail with.
+         */
+        fail(rule: BrokenRule, argsOrMessage: any | string);
+    }
+}
+
+AggregateRoot.prototype.fail = function (rule: BrokenRule, argsOrMessage: any | string) {
+    rule.fail(argsOrMessage, this.constructor.name);
+}
+
+

--- a/Source/typescript/backend/aggregates/BrokenRule.ts
+++ b/Source/typescript/backend/aggregates/BrokenRule.ts
@@ -79,6 +79,6 @@ declare module '@dolittle/sdk.aggregates' {
 
 AggregateRoot.prototype.fail = function (rule: BrokenRule, argsOrMessage: any | string) {
     rule.fail(argsOrMessage, this.constructor.name);
-}
+};
 
 

--- a/Source/typescript/backend/aggregates/IAggregate.ts
+++ b/Source/typescript/backend/aggregates/IAggregate.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AggregateRoot, IAggregateRootOperations } from '@dolittle/sdk.aggregates';
+import { Constructor } from '@dolittle/types';
+import { EventSourceId } from '@dolittle/sdk.events';
+import { Guid } from '@dolittle/rudiments';
+
+export abstract class IAggregate {
+    abstract of<TAggregate extends AggregateRoot>(type: Constructor<TAggregate>, eventSourceId: EventSourceId | Guid | string): Promise<IAggregateRootOperations<TAggregate>>;
+}
+
+

--- a/Source/typescript/backend/aggregates/index.ts
+++ b/Source/typescript/backend/aggregates/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export * from './BrokenRule';
+export * from './IAggregate';
+export * from './Aggregate';

--- a/Source/typescript/backend/data/BrokenRuleErrorInterceptor.ts
+++ b/Source/typescript/backend/data/BrokenRuleErrorInterceptor.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { MiddlewareInterface, NextFn, ResolverData } from 'type-graphql';
+import { BrokenRuleError } from '../aggregates/BrokenRule';
+
+export class BrokenRuleErrorInterceptor implements MiddlewareInterface {
+    async use({ context, info }: ResolverData<any>, next: NextFn) {
+        try {
+            return await next();
+        } catch (err) {
+            if (err instanceof BrokenRuleError) {
+                throw err;
+            } else {
+                throw err;
+            }
+        }
+    }
+}

--- a/Source/typescript/backend/data/GraphQLSchema.ts
+++ b/Source/typescript/backend/data/GraphQLSchema.ts
@@ -3,11 +3,12 @@
 
 import { Guid } from '@dolittle/rudiments';
 import { Constructor } from '@dolittle/types';
-import { buildSchema, Field, ObjectType, Query, Resolver, ResolverData } from 'type-graphql';
+import { buildSchema, Field, MiddlewareFn, ObjectType, Query, Resolver, ResolverData } from 'type-graphql';
 import { GraphQLSchema } from 'graphql';
 
 import { GuidScalar } from '.';
 import { container } from 'tsyringe';
+import { BrokenErrorInterceptor } from './BrokenErrorInterceptor';
 
 @ObjectType()
 class Nothing {
@@ -27,6 +28,7 @@ export async function getSchemaFor(resolvers: Constructor[]): Promise<GraphQLSch
 
     const schema = await buildSchema({
         resolvers: resolvers.length > 0 ? resolvers as any : [NoQueries],
+        globalMiddlewares: [BrokenErrorInterceptor],
         container: {
             get(someClass: any, resolverData: ResolverData<any>): any | Promise<any> {
                 return container.resolve(someClass);

--- a/Source/typescript/backend/data/GraphQLSchema.ts
+++ b/Source/typescript/backend/data/GraphQLSchema.ts
@@ -8,7 +8,7 @@ import { GraphQLSchema } from 'graphql';
 
 import { GuidScalar } from '.';
 import { container } from 'tsyringe';
-import { BrokenErrorInterceptor } from './BrokenErrorInterceptor';
+import { BrokenRuleErrorInterceptor } from './BrokenRuleErrorInterceptor';
 
 @ObjectType()
 class Nothing {
@@ -28,7 +28,7 @@ export async function getSchemaFor(resolvers: Constructor[]): Promise<GraphQLSch
 
     const schema = await buildSchema({
         resolvers: resolvers.length > 0 ? resolvers as any : [NoQueries],
-        globalMiddlewares: [BrokenErrorInterceptor],
+        globalMiddlewares: [BrokenRuleErrorInterceptor],
         container: {
             get(someClass: any, resolverData: ResolverData<any>): any | Promise<any> {
                 return container.resolve(someClass);

--- a/Source/typescript/backend/dolittle/IEventStore.ts
+++ b/Source/typescript/backend/dolittle/IEventStore.ts
@@ -5,10 +5,45 @@ import { Guid } from '@dolittle/rudiments';
 import { EventType } from '@dolittle/sdk.artifacts';
 import { Cancellation } from '@dolittle/sdk.resilience';
 
-import { IEventStore as IActualEventStore, UncommittedEvent, CommitEventsResult } from '@dolittle/sdk.events';
+import {
+    IEventStore as IActualEventStore,
+    UncommittedEvent,
+    CommitEventsResult,
+    UncommittedAggregateEvents,
+    CommitAggregateEventsResult,
+    CommitForAggregateBuilder,
+    CommittedAggregateEvents,
+    AggregateRootId,
+    AggregateRootVersion,
+    EventTypeId,
+    EventSourceId,
+
+} from '@dolittle/sdk.events';
 
 export abstract class IEventStore implements IActualEventStore {
-    abstract commit(event: any, eventSourceId: Guid | string, eventType?: EventType | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+    /** @inheritdoc */
+    abstract commit(event: any, eventSourceId: EventSourceId | Guid | string, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+
+    /** @inheritdoc */
     abstract commit(eventOrEvents: UncommittedEvent | UncommittedEvent[], cancellation?: Cancellation): Promise<CommitEventsResult>;
-    abstract commitPublic(event: any, eventSourceId: Guid | string, eventType?: EventType | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+
+    /** @inheritdoc */
+    abstract commitPublic(event: any, eventSourceId: EventSourceId |Guid | string, eventType?: EventType | Guid | string, cancellation?: Cancellation): Promise<CommitEventsResult>;
+
+    /** @inheritdoc */
+    abstract commitForAggregate(event: any, eventSourceId: EventSourceId | Guid | string, aggregateRootId: AggregateRootId, expectedAggregateRootVersion: AggregateRootVersion, eventType?: EventType | EventTypeId | Guid | string, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
+
+    /** @inheritdoc */
+    abstract commitForAggregate(events: UncommittedAggregateEvents, cancellation?: Cancellation): Promise<CommitAggregateEventsResult>;
+
+    /** @inheritdoc */
+    abstract forAggregate(aggregateRootId: AggregateRootId): CommitForAggregateBuilder;
+
+    /** @inheritdoc */
+    abstract fetchForAggregate(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): Promise<CommittedAggregateEvents>;
+
+    /** @inheritdoc */
+    abstract fetchForAggregateSync(aggregateRootId: AggregateRootId, eventSourceId: EventSourceId, cancellation?: Cancellation): CommittedAggregateEvents;
 }
+
+

--- a/Source/typescript/backend/index.ts
+++ b/Source/typescript/backend/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+export * from './aggregates';
 export * from './Configuration';
 export * from './Host';
 export * from './logging';

--- a/Source/typescript/backend/package.json
+++ b/Source/typescript/backend/package.json
@@ -36,8 +36,8 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
-        "@dolittle/projections": "1.1.1",
-        "@dolittle/sdk": "14.1.0",
+        "@dolittle/projections": "2.0.0",
+        "@dolittle/sdk": "14.3.0",
         "@types/mongodb": "3.6.8",
         "apollo-server-express": "2.19.0",
         "body-parser": "1.19.0",


### PR DESCRIPTION
### Added

- eventTypes and eventHandlerTypes can now be configured during start of host
- BrokenRule, typically used in aggregates to convey when something is not allowed - a broken rule
- Aggregate support for IoC purposes

### Changed

- Upgraded to version 14.3.0 of the TypeScript SDK
- Upgraded to version 2.0.0 of the Dolittle declarative projections
- Upgraded samples to use vrsion 5.5.0 of the Dolittle Runtime