### PR TITLE
Map clients in memory and check if connected before making connection

### DIFF
--- a/Source/typescript/backend/mongodb/MongoDatabase.ts
+++ b/Source/typescript/backend/mongodb/MongoDatabase.ts
@@ -38,7 +38,10 @@ export class MongoDatabase implements IMongoDatabase {
             }
         }
 
-        await this._mongoClient.connect();
+        if(!this._mongoClient.isConnected()) {
+            await this._mongoClient.connect();
+        }
+        
         const db = this._mongoClient.db(this._configuration.database);
         if (options) {
             return db.collection(name, options);

--- a/Source/typescript/backend/mongodb/MongoDb.ts
+++ b/Source/typescript/backend/mongodb/MongoDb.ts
@@ -12,6 +12,9 @@ import { IMongoDatabase } from './IMongoDatabase';
 import { MongoDatabase } from './MongoDatabase';
 import { MongoDatabaseProvider } from './MongoDatabaseProvider';
 
+
+const clientsPerTenant: Map<string, MongoClient> = new Map();
+
 export class MongoDb {
 
     static initialize() {
@@ -25,8 +28,14 @@ export class MongoDb {
         });
         container.register(MongoClient, {
             useFactory: (dependencyContainer: DependencyContainer) => {
+                const tenantId =  getCurrentContext().tenantId.toString();
+                if(clientsPerTenant.has(tenantId)) {
+                    return clientsPerTenant.get(tenantId);
+                }
+
                 const configuration = dependencyContainer.resolve(MongoDbReadModelsConfiguration);
                 const client = new MongoClient(configuration.host, { useNewUrlParser: true, useUnifiedTopology: true });
+                clientsPerTenant.set(tenantId, client);
                 return client;
             }
         });


### PR DESCRIPTION
## Summary

Keep mongo clients as singleton in container per tenant id. 
Also checks connection state before connecting in `MongoDatabase.collection`.

### Fixed

- New connections being made for every call to `IMongoDatabase`
